### PR TITLE
Device expressions

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,117 @@
+# Rubber Duck — Phase 3 Handoff
+
+## What was done
+
+### Phase 1: Hardware + Voice (commits up to `2388420`)
+- Teensy 4.0 firmware: servo, I2S chirps, bidirectional USB audio
+- Widget: STT/TTS, wake word ("ducky"), serial comms
+- Python eval service: Claude Haiku scoring, WebSocket broadcast
+- Hook scripts connecting Claude Code events to the duck
+
+### Phase 2: Modularity + Modes (commits up to `db6c597`)
+- Refactored widget into focused components (STTEngine, TTSEngine, WakeWordProcessor, etc.)
+- Added critic/relay voice modes with Teensy button toggle
+- Expression engine mapping scores to widget animations
+
+### Phase 3: Swift Consolidation (commit `39cabc4`)
+- **Eliminated the Python service entirely.** The widget now embeds a Hummingbird 2 HTTP+WebSocket server.
+- One self-contained macOS app — drag to Applications, done.
+- New modules: `ClaudeEvaluator`, `DuckServer`, `PermissionGate`, `TmuxBridge`, `WebSocketBroadcaster`, `LocalEvalTransport`
+- Deleted: `ServiceProcess.swift` (managed the Python process lifecycle)
+- API key lookup: `ANTHROPIC_API_KEY` env var → `~/.duck/api_key` → `service/.env`
+- Dashboard and 3D viewer bundled as Swift Package resources
+- Fixed PermissionGate crash (`Task.detached` for timeout, not `Task`)
+
+## Current state
+
+**What works end-to-end:**
+- `make run` → widget launches, server binds `:3333`, hooks fire, duck evaluates + speaks + animates + moves servo
+- Voice input via "ducky [command]" → transcribed → tmux → Claude Code
+- Voice permissions: duck asks, you answer yes/no/first/second
+- Dashboard at `localhost:3333`, 3D viewer at `localhost:3333/viewer`
+- All audio routes through Teensy speaker (not laptop)
+
+**Known limitations:**
+- `make debug` (terminal launch) doesn't get macOS mic permissions — use `make run`
+- No retry logic on Anthropic API failures (returns zero scores silently)
+- TmuxBridge blocks the calling thread on `waitUntilExit()` — fine for now but could hang if tmux session is missing
+- Localhost WebSocket is open to any local process (acceptable for a dev tool)
+
+## What's next: Hardware Expressions + Prompt Refinement
+
+The software is stable. The next phase is about making the duck **feel right** — refining how it physically and vocally reacts to code.
+
+### Hardware Expression Tuning
+
+**Servo behavior:**
+- The servo uses spring physics (easing.ino) but the reducer mapping is basic. Experiment with:
+  - Tilt angle range (currently maps soundness → base angle)
+  - Speed/snap for high-ambition scores
+  - Wiggle amplitude and frequency for risky code
+  - Whether the duck should "nod" on permission approval or "shake" on deny
+- Consider adding a second servo for a different axis of expression (e.g., left-right shake vs up-down nod)
+
+**Chirp synthesis:**
+- Current chirps: ascending sweep = positive, descending = negative, sawtooth = risky
+- Room to explore: chord progressions, rhythm patterns, different waveforms for different dimensions
+- The mixer gain (4.5x) may need adjusting if TTS and chirps fight each other
+
+**LED bar (currently disabled):**
+- `LEDControl.ino` exists but `ENABLE_LED_DUCK` is false — no matching NeoPixel hardware yet
+- If adding LEDs to the new breadboard, the reducer mapping is already scaffolded
+
+**Button input:**
+- Teensy already reads a button for critic/relay mode toggle
+- Could add more buttons for quick feedback (thumbs up/down, "say that again")
+
+### Prompt Refinement
+
+**Eval prompt (`ClaudeEvaluator.swift`):**
+- The system prompt tells Haiku to score on 5 dimensions and give a reaction + summary
+- The reaction is the duck's "personality" — currently max 10 words, snarky-but-helpful
+- Tuning opportunities:
+  - Reaction tone: more/less snarky, more domain-specific, seasonal moods
+  - Score calibration: Haiku tends to be generous — consider adjusting the prompt to be more discriminating
+  - Summary usefulness: currently one-line, could be more actionable
+  - Context window: the `user_context` field sends recent conversation context but isn't heavily used yet
+
+**Permission voice prompts (`PermissionGate.describeSuggestion`):**
+- Converts permission suggestions to TTS-friendly labels
+- Current labels are functional but could be more natural ("wanna let it read that file?")
+
+**Critic mode prompt:**
+- The relay/critic mode (from Phase 2) has its own prompt style — may need alignment with the new eval prompt
+
+### Key files to modify
+
+| What | File | Notes |
+|------|------|-------|
+| Eval prompt / personality | `widget/.../ClaudeEvaluator.swift` | System prompt, reaction style, score calibration |
+| Permission voice labels | `widget/.../PermissionGate.swift` | `describeSuggestion()` |
+| Servo reducer | `firmware/.../ServoControl.ino` | Angle mapping, spring constants |
+| Chirp reducer | `firmware/.../I2SAudio.ino` | Frequency, waveform, duration |
+| Expression engine | `widget/.../ExpressionEngine.swift` | Score → widget animation mapping |
+| Serial protocol | `firmware/.../SerialProtocol.ino` + `widget/.../SerialManager.swift` | If adding new commands |
+| Config flags | `firmware/.../Config.h` | Enable/disable hardware features |
+
+### Dev workflow for tuning
+
+```bash
+# Widget changes: rebuild and relaunch
+cd widget && make run
+
+# Firmware changes: Arduino IDE → Upload, then relaunch widget
+# (serial reconnects automatically)
+
+# Test eval without full pipeline
+curl -X POST http://localhost:3333/evaluate \
+  -H "Content-Type: application/json" \
+  -d '{"text":"your test prompt here","source":"test"}'
+
+# Watch live scores
+open http://localhost:3333          # dashboard
+open http://localhost:3333/viewer   # 3D viewer
+
+# Check logs
+tail -f ~/Library/Logs/RubberDuck.log
+```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ Claude Code    Dashboard/    Teensy 4.0
 
 ## Hardware
 
+### Bill of Materials
+
+| Component | Qty | Role | Notes |
+|-----------|-----|------|-------|
+| **Teensy 4.0** | 1 | Main controller | USB Type: Serial + MIDI + Audio |
+| **MG90S micro servo** | 1 | Sentiment tilt | Pin 3 (PWM), 4.8V from USB |
+| **MAX98357 I2S DAC** | 1 | Audio amplifier | BCLK=21, LRCLK=20, DIN=7 |
+| **Mini oval speaker** 8Ω 1W | 1 | Chirps + TTS voice | [Adafruit 3923](https://www.adafruit.com/product/3923) |
+| **Electret microphone** (with breakout/amp) | 1 | Voice input to Mac | Pin A0 (analog) → USB Audio |
+| **Tactile button** | 1 | Mode toggle (critic/relay) | Pin 2 (internal pullup) |
+| **JST PH 2-pin cable** (male, 20cm) | 1 | Speaker connector | [Adafruit 3814](https://www.adafruit.com/product/3814) |
+| **JST PH 2-pin jack** (PCB mount) | 1 | Speaker receptacle | [Adafruit 4714](https://www.adafruit.com/product/4714) |
+| **Breadboard** | 1 | Prototyping base | Half-size works |
+| **Micro USB cable** | 1 | Power + data | Teensy to Mac |
+| **Hookup wire** | — | Connections | 22 AWG solid core |
+
 ### Current Build
 
 | Component | Role | Connection |

--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@ A physical IoT companion for Claude Code. It watches your coding sessions, evalu
                      You (speaking)
                           | voice (electret mic → Teensy USB → Mac)
                           v
-               .--- Widget (SwiftUI) ---.
-               |  * Apple Speech STT    |
-               |  * TTS via say -a      |--------> Teensy speaker
-               |  * SerialManager       |  (USB Audio out → I2S DAC)
-               |  * ServiceProcess      |
-               '---+-------+-------+----'
+               .--- Widget (SwiftUI) ---------.
+               |  * Apple Speech STT          |
+               |  * TTS via say -a            |--------> Teensy speaker
+               |  * SerialManager             |  (USB Audio out → I2S DAC)
+               |  * Embedded HTTP+WS Server   |
+               |    (Hummingbird 2 :3333)      |
+               '---+-------+-------+----------'
                    |       |       |
           voice/   |   WebSocket   |   serial (9600 baud)
        permission  |       |       |
                    v       v       v
-Claude Code    Eval Service    Teensy 4.0
-  (tmux)       (Python :3333)  servo + I2S audio + USB mic
+Claude Code    Dashboard/    Teensy 4.0
+  (tmux)       Viewer        servo + I2S audio + USB mic
   |-- hooks -----> |               |
   |  UserPrompt    |               | I2S (BCLK=21, LRCLK=20, DIN=7)
   |  Stop          |               v
@@ -30,13 +31,14 @@ Claude Code    Eval Service    Teensy 4.0
 
 ### Data Flow
 
-1. **Hooks** fire on Claude Code events (user prompt, response, permission request) and POST to the eval service
-2. **Eval service** scores text via Claude Haiku on 5 dimensions, broadcasts results via WebSocket
-3. **Widget** receives scores, animates the duck face, speaks reactions via TTS, sends scores to Teensy via serial
-4. **Teensy** reacts physically: servo tilts based on sentiment, I2S chirps play through speaker (ascending = positive, descending = negative, buzzy = risky)
-5. **Voice input**: say "ducky [command]" — widget transcribes, sends to service, which injects into Claude Code via `tmux send-keys`
-6. **Voice permissions**: when Claude needs approval, the duck asks you out loud. Say "yes", "no", "first", "second", etc.
-7. **TTS output**: duck voice ("Boing") routes through Teensy USB Audio to the physical speaker via `say -a`, mixed with chirps through the I2S DAC
+1. **Hooks** fire on Claude Code events (user prompt, response, permission request) and POST to the widget's embedded server on `:3333`
+2. **ClaudeEvaluator** scores text via Claude Haiku on 5 dimensions, returns scores + reaction + summary
+3. **Widget** receives scores in-process via `LocalEvalTransport`, animates the duck face, speaks reactions via TTS, sends scores to Teensy via serial
+4. **WebSocketBroadcaster** fans out results to any connected dashboard/viewer clients
+5. **Teensy** reacts physically: servo tilts based on sentiment, I2S chirps play through speaker (ascending = positive, descending = negative, buzzy = risky)
+6. **Voice input**: say "ducky [command]" — widget transcribes, TmuxBridge injects into Claude Code via `tmux send-keys`
+7. **Voice permissions**: when Claude needs approval, the duck asks you out loud. Say "yes", "no", "first", "second", etc.
+8. **TTS output**: duck voice ("Boing") routes through Teensy USB Audio to the physical speaker via `say -a`, mixed with chirps through the I2S DAC
 
 ## Hardware
 
@@ -111,38 +113,59 @@ Each prompt and response is scored from -1.0 to +1.0 on:
 - **elegance** — clean/clear vs hacky/convoluted
 - **risk** — could-go-wrong vs safe/predictable
 
-Plus a short gut-reaction quote from the duck (max 10 words).
+Plus a short gut-reaction quote from the duck (max 10 words) and a one-line summary.
 
 ## Components
 
 ### Widget (`widget/`)
-SwiftUI macOS app — the duck's brain. Owns all I/O:
-- **SpeechService** — Apple Speech STT + `say -a` TTS routed to Teensy speaker (Boing voice)
-- **SerialManager** — USB serial to Teensy for eval scores
-- **EvalService** — WebSocket client receiving eval scores from service
-- **ServiceProcess** — auto-launches the Python eval service, health monitoring, tmux session management
+SwiftUI macOS app — the duck's brain. Self-contained: no external services needed.
+
+**Server (embedded):**
+- **DuckServer** — Hummingbird 2 HTTP + WebSocket server on `:3333`, replaces the old Python service
+- **ClaudeEvaluator** — calls Anthropic Messages API directly via URLSession (Claude Haiku)
+- **PermissionGate** — actor-based async blocking until voice response or 30s timeout
+- **WebSocketBroadcaster** — fans out eval results and permission events to dashboard/viewer clients
+- **TmuxBridge** — injects voice commands into Claude Code via `tmux send-keys`
+- **LocalEvalTransport** — in-process delivery of eval results (no WebSocket round-trip for the widget itself)
+
+**Speech:**
+- **SpeechService** — orchestrates STT, TTS, wake word detection, and permission voice gate
+- **STTEngine** — Apple Speech framework recognition with Teensy mic input
+- **TTSEngine** — `say -a` TTS routed to Teensy speaker (Boing voice)
+- **WakeWordProcessor** — "ducky" detection and command extraction
+- **PermissionVoiceGate** — yes/no/ordinal word matching for permission responses
+- **AudioDeviceDiscovery** — CoreAudio enumeration, Teensy detection
+
+**UI:**
 - **DuckView** — animated yellow cube with expression engine, context menu
+- **ExpressionEngine** — maps eval scores to facial animations
+- **DuckTheme** — visual styling
+
+**Hardware bridge:**
+- **SerialManager** — USB serial to Teensy for eval scores
+- **EvalService** — transport-agnostic eval result handler (supports both local and WebSocket transports)
 
 Right-click menu: Start/Stop Listening, Start Claude Session, status info, Quit.
 
-### Service (`service/`)
-Python server on `localhost:3333`. Stateless eval + broadcast:
-- `server.py` — eval via Claude Haiku, WebSocket broadcast, permission gate, tmux voice bridge
+### Server Routes (`:3333`)
 
 | Route | Description |
 |-------|-------------|
-| `/` | Bar chart dashboard |
-| `/viewer` | Three.js 3D duck viewer |
-| `/ws` | WebSocket for live updates |
-| `/evaluate` | POST — trigger evaluation |
-| `/permission` | POST — voice permission gate (blocking) |
-| `/health` | Service status |
+| `GET /` | Bar chart dashboard |
+| `GET /viewer` | Three.js 3D duck viewer |
+| `GET /ws` | WebSocket for live updates |
+| `POST /evaluate` | Trigger evaluation (called by hooks) |
+| `POST /permission` | Voice permission gate — blocks until response |
+| `GET /health` | Server status JSON |
 
 ### Scripts (`scripts/`)
-- `duck-session` — tmux launcher: Claude Code + eval service in split panes
+- `duck-session` — tmux launcher: Claude Code + widget in split panes
 - `on-user-prompt.sh` — hook: captures user input (UserPromptSubmit)
 - `on-claude-stop.sh` — hook: captures Claude's response (Stop)
 - `on-permission-request.sh` — hook: voice-gated permission approval (blocking)
+
+### Service (`service/`)
+The original Python eval service. **No longer required** — the widget embeds all functionality natively. Kept for reference and standalone/remote use cases.
 
 ### Firmware (`firmware/rubber_duck/`)
 Teensy 4.0 Arduino firmware — multi-file sketch:
@@ -158,7 +181,7 @@ Teensy 4.0 Arduino firmware — multi-file sketch:
 | `SerialProtocol.ino` | Score parsing, test commands, ping |
 | `Easing.ino` | Quintic easing for servo smoothness |
 
-### 3D Viewer (`service/viewer.html`)
+### 3D Viewer (`service/viewer.html` / bundled in widget)
 Three.js scene with both duck prototypes side by side:
 - **Servo Duck** — yellow panel with rotating beak disc, spring physics
 - **LED Duck** — green PCB with 10-segment bar graph, piezo sound
@@ -169,7 +192,6 @@ Three.js scene with both duck prototypes side by side:
 
 - macOS (Apple Speech framework required)
 - [Teensy 4.0](https://www.pjrc.com/store/teensy40.html) + [Teensyduino](https://www.pjrc.com/teensy/td_download.html) (for hardware)
-- Python 3.10+
 - Swift 5.9+ (ships with Xcode)
 - tmux (`brew install tmux`)
 - Anthropic API key
@@ -181,32 +203,28 @@ Three.js scene with both duck prototypes side by side:
 git clone https://github.com/ideo/Rubber-Duck.git
 cd Rubber-Duck
 
-# 2. Install Python dependencies
-cd service
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
+# 2. Set API key (pick one)
+export ANTHROPIC_API_KEY=sk-ant-...          # env var (session)
+echo "sk-ant-..." > ~/.duck/api_key          # persistent file
+echo "ANTHROPIC_API_KEY=sk-ant-..." > service/.env  # legacy .env
 
-# 3. Set API key
-echo "ANTHROPIC_API_KEY=sk-ant-..." > .env
-
-# 4. Flash Teensy firmware (Arduino IDE)
+# 3. Flash Teensy firmware (Arduino IDE)
 #    Board: Teensy 4.0
 #    USB Type: Serial + MIDI + Audio
 #    Open firmware/rubber_duck/rubber_duck.ino → Upload
 
-# 5. Launch the widget (builds + runs, auto-starts eval service)
-cd ../widget
+# 4. Launch the widget (builds + runs, starts embedded server)
+cd widget
 make run
 ```
 
 ### Running
 
-**Widget (recommended):** Launch with `cd widget && make run`. The widget auto-starts the eval service. Right-click the duck to start a Claude Code terminal session (tmux), toggle voice listening, or quit.
+**Widget (recommended):** Launch with `cd widget && make run`. The widget starts an embedded HTTP+WebSocket server on `:3333`. Right-click the duck to start a Claude Code terminal session (tmux), toggle voice listening, or quit.
 
-**Full session:** `./scripts/duck-session` starts a tmux session with Claude Code in the main pane and the eval service in a split below.
+**Full session:** `./scripts/duck-session` starts a tmux session with Claude Code in the main pane.
 
-**Debug mode:** `cd widget && make debug` runs in the terminal with full log output (stdout).
+**Debug mode:** `cd widget && make debug` runs in the terminal with full log output. Note: mic permissions may not work in this mode — use `make run` for full functionality.
 
 **Without hardware:** Everything works except physical servo/audio. The widget still animates, speaks through Mac speakers, and bridges voice to Claude Code.
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,19 @@
 - [x] **Unified speech engine** (`service/speech.py`) — swappable STT/TTS backend
 - [x] **Voice → Claude Code bridge** — say "ducky [command]" → tmux send-keys
 - [x] **tmux session launcher** (`scripts/duck-session`)
-- [x] **USB Audio firmware** — Teensy mic (A0) → USB Audio → Mac
+- [x] **USB Audio firmware** — Teensy mic (A0) → USB Audio → Mac, TTS playback via I2S
 - [x] **macOS floating widget** — SwiftUI yellow cube with expression engine
 - [x] **Mac `say` TTS** — Boing voice for duck reactions
 - [x] **Plugin script structure** (`scripts/`) — portable hooks
+- [x] **I2S chirp engine** — sawtooth → bandpass filter, sentiment-driven quacks
+- [x] **Double-chirp patterns** — whistle (very positive) and uh-uh (very negative)
+- [x] **Whistle-servo coupling** — head bobs synced to chirp pitch hills
+- [x] **Expression decay** — poses spring back to center after 5s hold
+- [x] **Idle heartbeat** — gentle ±5° random drift when duck is at rest
+- [x] **Demo button presets** — 6 emotions (Impressed→Bored) cycled by button press
+- [x] **Permission nag system** — "uh-oh" chirp with 3-tier backoff (urgent→lazy→rare)
+- [x] **Widget ↔ Teensy permission wiring** — P,1/P,0 serial commands for nag lifecycle
+- [x] **Critic/Relay voice modes** — toggle via Teensy button or widget menu
 
 ## 🔮 Next: Realtime API Migration
 

--- a/docs/phase-2-hardware-handoff.md
+++ b/docs/phase-2-hardware-handoff.md
@@ -2,131 +2,171 @@
 
 ## Context
 
-Phase 1 (this branch → merged to main) delivers the full software loop:
-- Widget (SwiftUI) — visual duck, speech I/O, serial to Teensy
-- Eval service (Python) — Haiku scoring, WebSocket hub, permission gate
-- Hook scripts — Claude Code integration (user-prompt, claude-stop, permission)
-- Firmware (Teensy 4.0) — serial protocol, servo, LED, piezo
-
-Everything works end-to-end for the Tuesday demo. Phase 2 is about making the physical duck compelling for that demo.
+The firmware has evolved significantly from Phase 1. The servo duck now has a full expression system with quacky chirps, spring physics, whistle-servo coupling, permission nagging, and an idle heartbeat. This doc describes the current state.
 
 ---
 
-## What exists in firmware today
+## Firmware architecture
 
 ```
 firmware/rubber_duck/
-├── rubber_duck.ino      # Main loop, serial read, command dispatch
-├── SerialProtocol.ino   # Parse incoming serial commands (JSON)
-├── ServoControl.ino     # Servo positioning + easing
-├── LEDControl.ino       # NeoPixel/LED color control
-├── AudioBridge.ino      # USB Audio (Teensy as mic — partial/untested)
-└── Easing.ino           # Easing functions for smooth servo motion
+├── rubber_duck.ino      # Main loop, button handling, permission state machine
+├── Config.h             # All config values, data structures, externs
+├── SerialProtocol.ino   # CSV serial parser (evals, commands, audio, servo)
+├── ServoControl.ino     # Servo reducer, spring physics, calibration, demo presets
+├── I2SAudio.ino         # I2S chirp synthesis + TTS mixer + permission chirp
+├── LEDControl.ino       # LED bar graph (disabled — no hardware yet)
+├── AudioBridge.ino      # USB Audio bridge (mic → USB, USB TTS → speaker)
+└── Easing.ino           # Cubic/quartic/quintic ease + lerp
 ```
 
-### Serial protocol (what the widget sends)
+### Serial protocol (CSV, newline-terminated, 9600 baud)
 
-The widget's `SerialManager` sends JSON commands over USB serial at 115200 baud:
-
-```json
-{"type": "servo", "angle": 45}
-{"type": "led", "r": 255, "g": 200, "b": 0}
-{"type": "piezo", "freq": 440, "duration": 100}
-{"type": "mood", "creativity": 0.5, "soundness": -0.3, ...}
+**Evaluation scores** (sent by widget):
+```
+U,0.20,0.70,0.00,0.60,-0.30    # user evaluation
+C,0.20,0.70,0.00,0.60,-0.30    # claude evaluation
+# Order: creativity, soundness, ambition, elegance, risk (each -1.0 to 1.0)
 ```
 
-The `mood` command sends all five eval dimensions. Firmware maps these to physical behavior.
+**Permission commands** (sent by widget):
+```
+P,1     # enter permission pending (starts uh-oh nag loop)
+P,0     # permission resolved (stop nagging)
+P       # ping (responds with PONG)
+```
+
+**Servo commands**:
+```
+S,90    # set servo to absolute angle (10-170)
+S,C     # snap to center
+S,?     # report current angle
+CAL     # enter calibration mode
+N       # advance calibration step
+```
+
+**Audio commands**:
+```
+G,2.5   # set mic gain (0.0-10.0)
+M,1     # mute mic (M,0 to unmute)
+V       # report audio level (responds with L,0.45)
+```
+
+**Test commands**:
+```
+T       # positive test eval
+X       # negative test eval
+D       # cycle demo emotion preset (same as button press)
+```
 
 ---
 
-## What needs work for the demo
+## Expression system
 
-### 1. Mood-to-motion mapping
-The duck receives eval scores but the mapping to physical behavior needs tuning. This is where the personality lives in hardware.
+### How evals become physical reactions
 
-**Dimensions to map:**
-| Dimension | Positive (→1.0) | Negative (→-1.0) |
-|-----------|-----------------|-------------------|
-| creativity | Excited wiggle, rainbow LED | Bored slouch, dim LED |
-| soundness | Confident nod, green LED | Nervous shake, red LED |
-| ambition | Big motion, bright LED | Small motion, dim |
-| elegance | Smooth slow sweep, warm white | Jerky twitch, harsh color |
-| risk | Alert posture, orange pulse | Relaxed, steady blue |
+1. **Scores arrive** via serial → parsed into `EvalScores` struct
+2. **Servo reducer** maps weighted approval to angle (±80° from center)
+   - Approval = 0.35×soundness + 0.25×elegance + 0.20×creativity + 0.10×ambition - 0.10×risk
+   - Risk drives oscillation/wiggle amplitude
+3. **Chirp reducer** maps sentiment to frequency + chirp pattern
+   - Sawtooth waveform → bandpass filter (Q=5) for quack formant
+   - Positive: ascending, filter opens "ooo→ehhhh"
+   - Negative: descending, filter stays grumbly
+   - Very positive (>0.75): double-chirp whistle with servo head bob
+   - Very negative (<-0.4): double-chirp "uh-uh" grumble
+4. **Spring physics** drives servo smoothly to target (K=0.06, damping=0.82)
+5. **Expression decay** — pose held 5s, then springs back to center
+6. **Idle heartbeat** — gentle random ±5° hops every 3-8s when at rest
 
-The firmware should combine these into a coherent physical reaction — not five independent animations. One "mood pose" per eval.
+### Demo presets (button or serial `D`)
 
-### 2. Permission wobble
-When a permission request arrives, the duck should physically react:
-- Servo: nervous wobble/shake
-- LED: pulsing yellow/orange (attention needed)
-- Piezo: questioning chirp
+| # | Name | Feel |
+|---|------|------|
+| 0 | Impressed | Far right, ascending whistle |
+| 1 | Excited | Right, warm chirp |
+| 2 | Skeptical | Slight left, mild buzz |
+| 3 | Nervous | Center, strong wiggle |
+| 4 | Disgusted | Far left, descending grumble |
+| 5 | Bored | Near center, flat quiet |
 
-The widget already sends a distinct command for permission state. Firmware needs to handle it.
+Short press cycles through. Long press (2s) snaps to center.
 
-### 3. Reaction chirps
-Short piezo sounds for key moments:
-- Wake word detected: quick rising chirp
-- Permission approved: happy double-beep
-- Permission denied: sad descending tone
-- Eval reaction: varies by mood (happy quack, disappointed buzz, etc.)
+### Permission nag system
 
-### 4. Physical build
-- Mount servo(s) in the rubber duck body
-- Route LED to be visible (through translucent body or as eyes)
-- Position piezo for audible output
-- Cable management — single USB to Teensy
+When permission is needed (`P,1`), the duck plays a two-note descending "uh-oh" quack and jiggles. Repeats with backoff:
+- **Urgent** (0-30s): every 4-8 seconds
+- **Lazy** (30s-2min): every 15-30 seconds
+- **Rare** (2min+): every 5-10 minutes
 
----
-
-## What NOT to touch
-
-- **Widget** — working, don't change. It sends serial commands based on eval scores and permission state.
-- **Service** — working, don't change. It scores and broadcasts.
-- **Hook scripts** — working, don't change. They connect Claude Code to the service.
-- **Speech** — working in the widget. Don't move to Teensy (that's phase 3 / ESP32).
+Auto-resolves when any new eval arrives (means session moved on). Widget sends `P,0` on voice approval.
 
 ---
 
-## Hardware parts
+## Audio subsystem
 
-- **Teensy 4.0** — already in use, programmed via Arduino IDE / PlatformIO
-- **Servo(s)** — SG90 micro servo (head tilt, possibly body rotate)
-- **NeoPixels** — WS2812B strip or ring (mood color)
-- **Piezo buzzer** — passive piezo for tones
-- **Rubber duck** — the physical enclosure. Needs hollow body for components.
+### I2S output (MAX98357 DAC)
+
+Chirps + TTS playback through a single speaker:
+```
+chirpWave (sawtooth) → bandpass filter → mixer ch0 → I2S out
+USB TTS input                          → mixer ch1 →
+```
+
+### USB Audio (bidirectional)
+
+Teensy appears as a USB microphone + speaker to the Mac:
+- **Mic out**: Analog mic (A0) → gain stage → USB output
+- **TTS in**: Mac sends speech audio → mixed with chirps → I2S speaker
+
+Requires Arduino IDE USB Type: "Serial + MIDI + Audio"
+
+---
+
+## Config values (Config.h)
+
+All tunable values are `#define`s at the top of Config.h. Key ones:
+
+| Config | Value | What it does |
+|--------|-------|-------------|
+| `SERVO_CENTER` | 90° | Neutral position |
+| `SERVO_RANGE` | ±80° | Max swing from center |
+| `SPRING_K` | 0.06 | Spring stiffness |
+| `SPRING_DAMPING` | 0.82 | Motion damping |
+| `EXPRESSION_HOLD_MS` | 5000 | Hold pose before decay |
+| `IDLE_HOP_RANGE` | ±5° | Heartbeat drift range |
+| `IDLE_HOP_MIN_MS` / `MAX` | 3000 / 8000 | Time between hops |
+| `CHIRP_BASE_FREQ` | 280 Hz | Base chirp pitch |
+| `CHIRP_AMPLITUDE` | 0.6 | Chirp volume (0-1) |
+| `WHISTLE_SERVO_KICK` | 15° | Head bob during whistle |
+| `PERMISSION_NAG_BASE` | 6000 ms | Urgent nag interval |
+
+---
+
+## Widget integration
+
+The widget (SwiftUI) owns serial communication via `SerialManager`:
+- **Eval scores** → `sendScores()` on each eval event
+- **Permission pending** → `sendCommand("P,1")` when permission arrives
+- **Permission resolved** → `sendCommand("P,0")` via three paths:
+  1. Direct voice approval → `handlePermissionDecision()`
+  2. SwiftUI onChange → `handlePermissionResolved()`
+  3. New eval arrives → `handleNewEval()` sends P,0 as safety net
 
 ---
 
 ## Dev workflow
 
 ```bash
-# Open Arduino IDE with firmware
+# Flash firmware
+# Open Arduino IDE, select Teensy 4.0, USB Type: Serial + MIDI + Audio
 open firmware/rubber_duck/rubber_duck.ino
 
-# Or use PlatformIO
-cd firmware && pio run --target upload
-
-# Monitor serial output (debug)
-screen /dev/tty.usbmodem* 115200
-
-# Test with widget running
+# Run widget (builds + launches, auto-starts eval service)
 cd widget && make run
-# Widget auto-detects Teensy and sends commands
+
+# Test firmware standalone (Serial Monitor at 9600 baud)
+# Send: T (positive eval), X (negative), D (demo cycle)
+# Send: P,1 (start nag), P,0 (stop nag)
+# Send: S,? (report angle), S,C (snap center)
 ```
-
----
-
-## Success criteria for Tuesday demo
-
-The duck should:
-1. **Visibly react** when Claude gives a response — head tilt + LED color change
-2. **Wobble nervously** when permission is requested — unmistakable "it's asking you something"
-3. **Chirp** on key events — wake word, approval, denial
-4. **Feel alive** — smooth easing, not jerky. The motion should have character.
-
-It does NOT need to:
-- Be a polished product
-- Have perfect mood mapping (we can tune post-demo)
-- Support USB audio (phase 3)
-- Be wireless (phase 3 / ESP32)
-- Look beautiful (it's a prototype with wires showing — that's fine)

--- a/firmware/rubber_duck/AudioBridge.ino
+++ b/firmware/rubber_duck/AudioBridge.ino
@@ -73,16 +73,6 @@ float getMicLevel() {
   return audioLevel;
 }
 
-// ============================================================
-// VU Meter mode (optional — shows audio level on LED bar when idle)
-// ============================================================
-void showVUMeter() {
-  // Requires LED hardware — no-op without it
-  #if !ENABLE_LED_DUCK
-    return;
-  #endif
-}
-
 #else
 
 // Stubs when USB Audio is disabled
@@ -91,6 +81,5 @@ void updateAudioBridge() {}
 void setMicGain(float gain) {}
 void setMicMute(bool mute) {}
 float getMicLevel() { return 0.0; }
-void showVUMeter() {}
 
 #endif

--- a/firmware/rubber_duck/Config.h
+++ b/firmware/rubber_duck/Config.h
@@ -30,7 +30,7 @@
 #define LED_BRIGHTNESS   80   // Global brightness (0-255)
 
 // --- Button Config ---
-#define BUTTON_PIN       2    // Mode toggle button (digital input, internal pullup)
+#define BUTTON_PIN       11   // Calibration button (digital input, internal pullup)
 #define BUTTON_DEBOUNCE_MS 200
 
 // --- Serial Config ---
@@ -41,14 +41,35 @@
 #define SPRING_DAMPING   0.82f
 #define OSCILLATION_DECAY 0.95f
 
+// --- Expression Decay (return to rest) ---
+#define EXPRESSION_HOLD_MS   5000   // Hold pose before springing back to center (ms)
+#define EXPRESSION_RETURN_KICK 0.5f // Velocity kick for return (reaction kick is 1.5)
+
+// --- Idle Heartbeat (alive drift when at rest) ---
+#define IDLE_HOP_RANGE       5.0f   // ±degrees to drift (random target within this)
+#define IDLE_HOP_MIN_MS      3000   // Minimum time between hops (ms)
+#define IDLE_HOP_MAX_MS      8000   // Maximum time between hops (ms)
+#define IDLE_HOP_KICK        0.3f   // Gentle velocity kick toward new target
+
 // --- LED Animation ---
 #define LED_LERP_SPEED   0.08f
 #define LED_FLASH_MS     200
 
 // --- Chirp Config ---
-#define CHIRP_BASE_FREQ  400
+#define CHIRP_BASE_FREQ  280
 #define CHIRP_DURATION   250   // ms
 #define CHIRP_AMPLITUDE  0.6f  // 0.0-1.0 volume for I2S output
+#define WHISTLE_SERVO_KICK 15.0f // Degrees of head kick during whistle peak
+
+// --- Permission Nag Config ---
+#define PERMISSION_NAG_BASE     6000    // Urgent: 4-8s apart
+#define PERMISSION_NAG_JITTER   2000    // ±random jitter (ms)
+#define PERMISSION_BACKOFF_AT   30000   // 30s → lazy mode
+#define PERMISSION_LAZY_BASE    15000   // Lazy: 15-30s apart
+#define PERMISSION_LAZY_JITTER  15000
+#define PERMISSION_RARE_AT      120000  // 2min → rare mode
+#define PERMISSION_RARE_BASE    300000  // Rare: 5-10min apart
+#define PERMISSION_RARE_JITTER  300000
 
 // --- USB Audio Config ---
 #define MIC_DEFAULT_GAIN 2.0f  // Pre-amp gain for mic signal
@@ -90,6 +111,7 @@ struct ChirpTarget {
   int   endFreq;          // Hz end tone (ascending=good, descending=bad)
   bool  buzzy;            // sawtooth waveform instead of sine
   float sentiment;        // -1..1 for waveform shaping
+  bool  doubleChirp;      // two-note pattern: whistle (positive) or uh-uh (negative)
 };
 
 // ============================================================
@@ -98,5 +120,33 @@ struct ChirpTarget {
 
 extern EvalScores latestScores;
 extern bool       newEvalAvailable;
+
+// Servo control (defined in ServoControl.ino)
+extern bool  calibrationMode;
+extern float servoCurrentAngle;
+extern float servoTargetAngle;
+extern float servoOscillationAmp;
+extern float servoOscillationPhase;
+extern int   demoStep;
+
+// Chirp state (defined in I2SAudio.ino)
+extern float chirpServoOffset;  // Real-time servo kick from whistle pitch
+extern bool  i2sChirpActive;    // True while any chirp is playing
+
+// Permission state (defined in rubber_duck.ino)
+extern bool permissionPending;
+void enterPermission();
+void exitPermission();
+
+// Calibration functions (defined in ServoControl.ino)
+void enterCalibration();
+void advanceCalibration();
+void exitCalibration();
+void setServoAngleDirect(int angle);
+void snapToCenter();
+void triggerDemoPreset();
+
+// Audio functions (defined in I2SAudio.ino)
+void playPermissionChirp();
 
 #endif

--- a/firmware/rubber_duck/I2SAudio.ino
+++ b/firmware/rubber_duck/I2SAudio.ino
@@ -9,8 +9,8 @@
 //   BCLK = 21, LRCLK = 20, DIN = 7
 //
 // Audio graph:
-//   chirpWave ──→ mixer(ch0) ──→ i2sOut (speaker)
-//   usbIn    ──→ mixer(ch1) ──╯
+//   chirpWave ──→ chirpFilter(bandpass) ──→ mixer(ch0) ──→ i2sOut (speaker)
+//   usbIn    ─────────────────────────────→ mixer(ch1) ──╯
 //
 // Chirp vocabulary:
 //   - Ascending sine sweep = positive sentiment (happy)
@@ -23,19 +23,23 @@
 #include <Audio.h>
 
 // --- Audio Objects ---
-AudioSynthWaveform       chirpWave;
+AudioSynthWaveform       chirpWave;     // Main chirp oscillator
+AudioFilterStateVariable chirpFilter;   // Bandpass filter for quack formant
 AudioOutputI2S           i2sOut;
 
+// chirpWave → bandpass filter (output 1 = bandpass)
+AudioConnection          patchToFilter(chirpWave, 0, chirpFilter, 0);
+
 #if ENABLE_USB_AUDIO
-// --- TTS Mixer: chirps + USB audio from Mac → I2S speaker ---
+// --- TTS Mixer: filtered chirp + USB audio → I2S speaker ---
 AudioMixer4              i2sMixL;
 AudioMixer4              i2sMixR;
 
-// Chirp → mixer
-AudioConnection          patchChirpMixL(chirpWave, 0, i2sMixL, 0);
-AudioConnection          patchChirpMixR(chirpWave, 0, i2sMixR, 0);
+// Filtered chirp → mixer ch0
+AudioConnection          patchChirpMixL(chirpFilter, 1, i2sMixL, 0);  // output 1 = bandpass
+AudioConnection          patchChirpMixR(chirpFilter, 1, i2sMixR, 0);
 
-// USB TTS → mixer (usbIn defined in AudioBridge.ino)
+// USB TTS → mixer ch1 (usbIn defined in AudioBridge.ino)
 AudioConnection          patchTTSMixL(usbIn, 0, i2sMixL, 1);
 AudioConnection          patchTTSMixR(usbIn, 1, i2sMixR, 1);
 
@@ -44,10 +48,14 @@ AudioConnection          patchMixOutL(i2sMixL, 0, i2sOut, 0);
 AudioConnection          patchMixOutR(i2sMixR, 0, i2sOut, 1);
 
 #else
-// --- Direct chirp → I2S (no USB mixing) ---
-AudioConnection          patchChirpL(chirpWave, 0, i2sOut, 0);  // Left
-AudioConnection          patchChirpR(chirpWave, 0, i2sOut, 1);  // Right (mono → stereo)
+// --- Filtered chirp → I2S (no USB) ---
+AudioConnection          patchChirpL(chirpFilter, 1, i2sOut, 0);  // bandpass → left
+AudioConnection          patchChirpR(chirpFilter, 1, i2sOut, 1);  // bandpass → right
 #endif
+
+// --- Chirp-Servo Coupling ---
+float    chirpServoOffset = 0.0;   // Additive head kick during whistle
+bool     i2sIsWhistle = false;     // Track whether current chirp is a whistle
 
 // --- Chirp State ---
 bool     i2sChirpActive = false;
@@ -55,6 +63,39 @@ unsigned long i2sChirpStart = 0;
 int      i2sChirpStartFreq = 400;
 int      i2sChirpEndFreq = 600;
 int      i2sChirpDuration = CHIRP_DURATION;
+
+// --- Filter envelope state ---
+float    i2sFilterStartFreq = 350.0;   // "ooo" — closed, round
+float    i2sFilterEndFreq = 1800.0;    // "ehhhh" — open, clear
+float    i2sFilterRiseRate = 6.0;      // How fast filter opens
+bool     i2sFilterTrackHarmonic = false; // true = filter tracks oscillator (whistle), false = envelope
+
+// --- Double-chirp state (for "uh-uh" pattern) ---
+bool     i2sDoubleChirp = false;
+int      i2sChirp2StartFreq = 300;
+int      i2sChirp2PeakFreq = 500;   // Hill peak — note 2 rises here then falls
+int      i2sChirp2EndFreq = 180;
+int      i2sChirp2Duration = 350;
+int      i2sGapDuration = 60;  // silence between the two chirps
+
+// ============================================================
+// Helpers
+// ============================================================
+
+/// Hill envelope: 40% rise, 60% fall. t in [0,1] → [0,1]
+static float hillEnvelope(float t) {
+  if (t < 0.4f) return t / 0.4f;
+  return 1.0f - (t - 0.4f) / 0.6f;
+}
+
+/// Common chirp activation — resets state and starts playback
+static void startChirp(int startFreq, int waveform) {
+  chirpWave.begin(CHIRP_AMPLITUDE, startFreq, waveform);
+  chirpFilter.frequency(i2sFilterStartFreq);
+  i2sChirpActive = true;
+  i2sChirpStart = millis();
+  chirpServoOffset = 0.0;
+}
 
 // ============================================================
 // Setup (called from main setup())
@@ -65,9 +106,12 @@ void setupI2SAudio() {
   chirpWave.begin(0.0, 440, WAVEFORM_SINE);
   chirpWave.amplitude(0.0);  // Silent until chirp
 
+  // Bandpass filter: quack formant — resonance gives nasal character
+  chirpFilter.frequency(1800);  // Will be modulated by envelope
+  chirpFilter.resonance(5.0);   // Moderate Q for nasal peak (0.7-5.0)
+
   #if ENABLE_USB_AUDIO
-    // Mixer gains: chirps (ch0) + TTS from USB (ch1)
-    // TTS boosted — USB audio arrives quiet; 4.5x is the sweet spot
+    // Mixer gains: chirp (ch0) + TTS (ch1)
     i2sMixL.gain(0, 1.0);   // chirps at full volume
     i2sMixL.gain(1, 4.5);   // TTS loud but clean
     i2sMixR.gain(0, 1.0);
@@ -95,7 +139,8 @@ ChirpTarget chirpReducer(EvalScores &scores) {
     target.endFreq = target.startFreq * 0.6;
   }
 
-  target.buzzy = (scores.risk > 0.3);
+  target.buzzy = true;  // All sawtooth for now — filter needs harmonics to shape
+  target.doubleChirp = (sentiment < -0.4) || (sentiment > 0.75);  // two-note: uh-uh or whistle (rare)
 
   return target;
 }
@@ -108,11 +153,71 @@ void playI2SChirp(ChirpTarget &target) {
   i2sChirpStart = millis();
   i2sChirpStartFreq = target.startFreq;
   i2sChirpEndFreq = target.endFreq;
-  i2sChirpDuration = CHIRP_DURATION;
+  // Note 1 duration: whistle gets a longer lead-in, uh-uh stays snappy
+  if (target.doubleChirp && target.sentiment > 0) {
+    i2sChirpDuration = 500;   // Whistle: half speed test (was 250)
+  } else if (target.doubleChirp) {
+    i2sChirpDuration = 200;   // Uh-uh: quick
+  } else {
+    i2sChirpDuration = CHIRP_DURATION;
+  }
 
-  // Select waveform: sawtooth for buzzy/risky, sine for clean
-  chirpWave.begin(CHIRP_AMPLITUDE, target.startFreq,
-                  target.buzzy ? WAVEFORM_SAWTOOTH : WAVEFORM_SINE);
+  // Double-chirp setup — same structure, different freq profiles
+  //   Positive (whistle): "wh-WHEWWW!" — bright, soaring
+  //   Negative (uh-uh):   "uh, uh-UH-hh" — grumbly, drops low
+  i2sDoubleChirp = target.doubleChirp;
+  if (target.doubleChirp) {
+    if (target.sentiment > 0) {
+      // Whistle note 1: G4→C5
+      i2sChirpEndFreq = target.startFreq * 1.68;
+    } else {
+      // Uh-uh note 1: moderate rise
+      i2sChirpEndFreq = target.startFreq * 1.5;
+    }
+
+    if (target.sentiment > 0) {
+      // Whistle: G4→E5→G4 hill
+      i2sChirp2StartFreq = target.startFreq * 1.0;     // G4
+      i2sChirp2PeakFreq = target.startFreq * 1.68;     // E5
+      i2sChirp2EndFreq = target.startFreq * 1.0;        // G4
+      i2sChirp2Duration = 1200;  // Half speed test (was 600)
+      i2sGapDuration = 120;     // Half speed test (was 40) — servo needs time to dip
+    } else {
+      // Uh-uh: grumbly, drops well below
+      i2sChirp2StartFreq = target.startFreq * 0.9;    // Start near original
+      i2sChirp2PeakFreq = target.startFreq * 1.4;     // Rise higher than note 1
+      i2sChirp2EndFreq = target.startFreq * 0.45;     // Drop well below start
+      i2sChirp2Duration = 400;
+      i2sGapDuration = 50;
+    }
+  }
+
+  // Whistle servo coupling: time-based kick on top of expression angle
+  // Servo stays at expression target — offset adds head-tilt boost during whistle
+  i2sIsWhistle = target.doubleChirp && (target.sentiment > 0);
+  if (i2sIsWhistle) {
+    // Redistribute expression into 10-45° range so kick has room
+    float norm = servoTargetAngle / (float)SERVO_RANGE;  // 0..1
+    servoTargetAngle = 10.0f + norm * 35.0f;             // 10..45
+  }
+
+  // Filter envelope: "ooo" → "ehhhh" (closed → open)
+  // Positive chirps: opens wider and brighter
+  // Negative chirps: stays more closed/grumbly
+  if (target.sentiment > 0) {
+    i2sFilterStartFreq = 300.0;    // Round start
+    i2sFilterEndFreq = 2200.0;     // Opens bright
+    i2sFilterRiseRate = 5.0;       // Leisurely open
+  } else {
+    i2sFilterStartFreq = 250.0;    // Darker start
+    i2sFilterEndFreq = 1200.0;     // Doesn't open as much
+    i2sFilterRiseRate = 8.0;       // Faster — snappier quack
+  }
+
+  // Note 2 filter: whistle tracks harmonics, everything else uses envelope
+  i2sFilterTrackHarmonic = i2sIsWhistle;
+
+  startChirp(target.startFreq, WAVEFORM_SAWTOOTH);
 }
 
 // ============================================================
@@ -134,25 +239,134 @@ void updateI2SAudio() {
 
   unsigned long elapsed = millis() - i2sChirpStart;
 
+  // Filter envelope: opens from "ooo" to "ehhhh"
+  float elapsedSec = (float)elapsed / 1000.0;
+  float filterEnv = 1.0 - exp(-elapsedSec * i2sFilterRiseRate);  // 0→1 rising
+  float filterFreq = i2sFilterStartFreq + (i2sFilterEndFreq - i2sFilterStartFreq) * filterEnv;
+  chirpFilter.frequency(filterFreq);
+
   if (elapsed < (unsigned long)i2sChirpDuration) {
-    // Sweep frequency from start to end over duration
+    // First chirp (or only chirp): linear sweep
     float t = (float)elapsed / (float)i2sChirpDuration;
     int freq = i2sChirpStartFreq + (int)((i2sChirpEndFreq - i2sChirpStartFreq) * t);
     chirpWave.frequency(freq);
-  } else {
-    // Chirp done — silence
+
+    // Whistle servo: note 1 — up then down within the note
+    if (i2sIsWhistle) {
+      chirpServoOffset = hillEnvelope(t) * WHISTLE_SERVO_KICK;
+    }
+
+  }
+  else if (i2sDoubleChirp) {
+    unsigned long phase2Start = i2sChirpDuration + i2sGapDuration;
+    unsigned long phase2End = phase2Start + i2sChirp2Duration;
+
+    if (elapsed < (unsigned long)phase2Start) {
+      // Gap — silence between chirps, servo rests
+      chirpWave.amplitude(0.0);
+    }
+    else if (elapsed < (unsigned long)phase2End) {
+      // Second chirp: hill shape — rise to peak then fall
+      chirpWave.amplitude(CHIRP_AMPLITUDE);
+
+      // Compute pitch hill: 40% rise, 60% fall
+      float t = (float)(elapsed - phase2Start) / (float)i2sChirp2Duration;
+      float h = hillEnvelope(t);
+      int freq;
+      if (t < 0.4) {
+        freq = i2sChirp2StartFreq + (int)((i2sChirp2PeakFreq - i2sChirp2StartFreq) * h);
+      } else {
+        float tFall = (t - 0.4) / 0.6;
+        freq = i2sChirp2PeakFreq + (int)((i2sChirp2EndFreq - i2sChirp2PeakFreq) * tFall);
+      }
+      chirpWave.frequency(freq);
+
+      // Whistle servo: second kick — hill up then down
+      if (i2sIsWhistle) {
+        chirpServoOffset = h * WHISTLE_SERVO_KICK;
+      }
+
+      // Filter envelope for note 2
+      if (i2sFilterTrackHarmonic) {
+        // Whistle: filter tracks 3rd harmonic — stays locked to pitch
+        chirpFilter.frequency((float)freq * 3.0);
+      } else {
+        // Uh-uh / permission: monotonic envelope (ooo → ehhhh)
+        float note2FilterStart = (i2sChirp2StartFreq > i2sFilterStartFreq)
+          ? (float)i2sChirp2StartFreq * 0.9
+          : i2sFilterStartFreq;
+        float note2Sec = (float)(elapsed - phase2Start) / 1000.0;
+        float fEnv2 = 1.0 - exp(-note2Sec * i2sFilterRiseRate);
+        chirpFilter.frequency(note2FilterStart + (i2sFilterEndFreq - note2FilterStart) * fEnv2);
+      }
+    }
+    else {
+      // Done
+      chirpWave.amplitude(0.0);
+      chirpServoOffset = 0.0;
+      i2sChirpActive = false;
+      i2sDoubleChirp = false;
+      i2sIsWhistle = false;
+    }
+  }
+  else {
+    // Single chirp done — silence
     chirpWave.amplitude(0.0);
+    chirpServoOffset = 0.0;
     i2sChirpActive = false;
   }
+}
+
+// ============================================================
+// Permission chirp — "uh-oh" two-note descending quack
+// ============================================================
+// Same quacky sawtooth + bandpass as expressions, but with
+// a distinct two-note descending pattern. Uses the normal
+// "ooo→ehhhh" filter envelope — it IS the duck's voice.
+
+void playPermissionChirp() {
+  // Randomize root note: 220-280Hz range, note 2 is ~70% of note 1
+  int root = 220 + random(60);           // 220-280Hz
+  int lower = (int)(root * 0.70);        // ~154-196Hz
+
+  // Note 1: higher quack (the "uh") — snappy, open filter
+  i2sChirpStartFreq = root;
+  i2sChirpEndFreq = root;
+  i2sChirpDuration = 120;     // Quick
+
+  // Note 2: lower quack (the "oh") — closes filter back down
+  i2sDoubleChirp = true;
+  i2sChirp2StartFreq = lower;
+  i2sChirp2PeakFreq = lower;
+  i2sChirp2EndFreq = lower;
+  i2sChirp2Duration = 150 + random(80);   // 150-230ms — varies each nag
+  i2sGapDuration = 40 + random(100);     // 40-140ms — tight "uhoh" to drawn out "uh... oh"
+
+  // Filter: starts open (ehhhh), note 2 envelope closes it back (envelope, not harmonic)
+  i2sFilterStartFreq = 1400.0;
+  i2sFilterEndFreq = 300.0;
+  i2sFilterRiseRate = 6.0;
+  i2sFilterTrackHarmonic = false;
+  i2sIsWhistle = false;
+
+  startChirp(root, WAVEFORM_SAWTOOTH);
+
+  // Jiggle the servo — reuse the oscillation system
+  servoOscillationAmp = 6.0;
+  servoOscillationPhase = 0.0;
+
+  Serial.println("[perm] uh-oh chirp");
 }
 
 #else
 
 // Stubs when I2S Audio is disabled
+float chirpServoOffset = 0.0;
 void setupI2SAudio() {}
-ChirpTarget chirpReducer(EvalScores &scores) { return {400, 600, false, 0.0}; }
+ChirpTarget chirpReducer(EvalScores &scores) { return {400, 600, false, 0.0, false}; }
 void playI2SChirp(ChirpTarget &target) {}
 void playStartupChirp() {}
 void updateI2SAudio() {}
+void playPermissionChirp() {}
 
 #endif

--- a/firmware/rubber_duck/SerialProtocol.ino
+++ b/firmware/rubber_duck/SerialProtocol.ino
@@ -9,7 +9,16 @@
 // Also accepts test commands:
 //   T   → trigger test eval (positive)
 //   X   → trigger test eval (negative)
+//   D   → cycle demo emotion presets (same as button press)
 //   P   → ping (responds with "PONG")
+//   P,1 → enter permission pending (nag loop)
+//   P,0 → permission resolved (stop nagging)
+//
+// Servo/calibration commands:
+//   S,90   → set servo to absolute angle (10-170)
+//   S,C    → snap to center
+//   S,?    → report current servo angle
+//   CAL    → enter calibration mode
 //
 // Audio commands (USB Audio bridge):
 //   G,0.8  → set mic gain (0.0-10.0)
@@ -40,9 +49,17 @@ void readSerial() {
 void parseMessage(char *msg) {
   char source = msg[0];
 
-  // Test commands
+  // Ping / Permission control
   if (source == 'P') {
-    Serial.println("PONG");
+    if (msg[1] == ',' && msg[2] == '1') {
+      // P,1 → enter permission pending
+      enterPermission();
+    } else if (msg[1] == ',' && msg[2] == '0') {
+      // P,0 → permission resolved
+      exitPermission();
+    } else {
+      Serial.println("PONG");
+    }
     return;
   }
 
@@ -59,6 +76,12 @@ void parseMessage(char *msg) {
     latestScores = {0.8, -0.9, 0.9, -0.8, 0.9, 'U', true};
     newEvalAvailable = true;
     Serial.println("[duck] Test eval: negative");
+    return;
+  }
+
+  if (source == 'D') {
+    // Cycle demo emotion presets (same as button press)
+    triggerDemoPreset();
     return;
   }
 
@@ -80,6 +103,41 @@ void parseMessage(char *msg) {
   if (source == 'V') {
     // Report audio level
     Serial.println("L," + String(getMicLevel(), 3));
+    return;
+  }
+
+  // --- Servo/calibration commands ---
+  if (source == 'S') {
+    if (msg[1] == ',') {
+      if (msg[2] == 'C' || msg[2] == 'c') {
+        // S,C → snap to center
+        snapToCenter();
+      } else if (msg[2] == '?') {
+        // S,? → report current angle
+        int pos = (int)(SERVO_CENTER + servoCurrentAngle);
+        Serial.println("[servo] Current: " + String(pos) + " deg (offset " +
+                       String(servoCurrentAngle, 1) + " from " + String(SERVO_CENTER) + ")");
+        Serial.println("[servo] Target:  " + String((int)(SERVO_CENTER + servoTargetAngle)) + " deg");
+        Serial.println("[servo] Range:   " + String(SERVO_MIN) + " - " + String(SERVO_MAX));
+        Serial.println("[servo] Cal mode: " + String(calibrationMode ? "ON" : "OFF"));
+      } else {
+        // S,90 → set to specific angle
+        int angle = (int)strtof(msg + 2, NULL);
+        setServoAngleDirect(angle);
+      }
+    }
+    return;
+  }
+
+  // CAL → enter calibration mode from serial
+  if (strncmp(msg, "CAL", 3) == 0) {
+    enterCalibration();
+    return;
+  }
+
+  // N → advance calibration step (next)
+  if (source == 'N' && calibrationMode) {
+    advanceCalibration();
     return;
   }
 

--- a/firmware/rubber_duck/ServoControl.ino
+++ b/firmware/rubber_duck/ServoControl.ino
@@ -1,5 +1,5 @@
 // ============================================================
-// Servo Duck — Reducer + Control
+// Servo Duck — Reducer + Control + Calibration
 // ============================================================
 // The servo duck is a beak on a rotating disc.
 // Expression vocabulary:
@@ -7,6 +7,11 @@
 //   - Movement dynamics: spring physics with overshoot
 //   - Oscillation/wiggle: high risk triggers jitter
 //   - Easing quality: elegance → smoother motion
+//
+// Calibration mode (button on pin 2):
+//   Short press cycles: CENTER → MIN → MAX → CENTER → exit
+//   Long press (2s): instant snap to CENTER from anywhere
+//   Serial "S,90": set arbitrary angle (10-170)
 
 // --- Servo State ---
 float servoCurrentAngle = 0.0;
@@ -15,6 +20,35 @@ float servoVelocity     = 0.0;
 
 float servoOscillationAmp   = 0.0;
 float servoOscillationPhase = 0.0;
+
+unsigned long lastEvalTime = 0;  // For expression decay back to rest
+
+// --- Idle Heartbeat State ---
+unsigned long nextIdleHop = 0;   // When to pick a new idle target
+
+// --- Calibration State ---
+bool  calibrationMode = false;
+int   calibrationStep = 0;  // 0=center, 1=min, 2=max, 3=center (then exit)
+const int calibrationAngles[] = { SERVO_CENTER, SERVO_MIN, SERVO_MAX, SERVO_CENTER };
+const char* calibrationLabels[] = { "CENTER (90)", "MIN (10)", "MAX (170)", "CENTER (90)" };
+#define CALIBRATION_STEPS 4
+
+// --- Demo Emotion Presets ---
+// Each fires through the existing eval pipeline (servo + chirp reducers)
+//                                     cre   snd   amb   elg   risk
+const EvalScores demoPresets[] = {
+  {  0.70,  0.95,  0.50,  0.90, -0.30, 'U', true },  // 0: Impressed
+  {  0.95,  0.50,  0.90,  0.60,  0.20, 'U', true },  // 1: Excited
+  {  0.10, -0.30,  0.20, -0.10,  0.50, 'U', true },  // 2: Skeptical
+  {  0.30,  0.20,  0.60,  0.10,  0.90, 'U', true },  // 3: Nervous
+  { -0.60, -0.95,  0.20, -0.80,  0.85, 'U', true },  // 4: Disgusted
+  { -0.20,  0.10, -0.80,  0.00, -0.10, 'U', true },  // 5: Bored
+};
+const char* demoLabels[] = {
+  "IMPRESSED", "EXCITED", "SKEPTICAL", "NERVOUS", "DISGUSTED", "BORED"
+};
+#define NUM_DEMO_PRESETS 6
+int demoStep = 0;
 
 // ============================================================
 // REDUCER: scores → servo target
@@ -49,6 +83,7 @@ void setServoTarget(ServoTarget &target) {
   servoTargetAngle = target.angle;
   servoOscillationAmp = target.oscillationAmp;
   servoOscillationPhase = 0;
+  lastEvalTime = millis();  // Reset decay timer
 
   // Give it a kick in the right direction
   float direction = (servoTargetAngle > servoCurrentAngle) ? 1.0 : -1.0;
@@ -59,6 +94,25 @@ void setServoTarget(ServoTarget &target) {
 // Fixed-rate update (called every SERVO_UPDATE_MS)
 // ============================================================
 void updateServo() {
+  unsigned long now = millis();
+
+  // Return to rest: after hold period, spring back to center (gentler kick)
+  if ((now - lastEvalTime) > EXPRESSION_HOLD_MS && abs(servoTargetAngle) > 0.5) {
+    float direction = (0 > servoCurrentAngle) ? 1.0 : -1.0;
+    servoTargetAngle = 0;
+    servoVelocity += direction * EXPRESSION_RETURN_KICK;
+  }
+
+  // Idle heartbeat: gentle random hops when at rest
+  if (!permissionPending && !i2sChirpActive &&
+      (now - lastEvalTime) > EXPRESSION_HOLD_MS && now > nextIdleHop) {
+    float hop = ((float)random(-100, 101) / 100.0f) * IDLE_HOP_RANGE;  // ±IDLE_HOP_RANGE
+    servoTargetAngle = hop;
+    float direction = (hop > servoCurrentAngle) ? 1.0f : -1.0f;
+    servoVelocity += direction * IDLE_HOP_KICK;
+    nextIdleHop = now + IDLE_HOP_MIN_MS + random(IDLE_HOP_MAX_MS - IDLE_HOP_MIN_MS);
+  }
+
   // Spring physics: pull toward target
   float diff = servoTargetAngle - servoCurrentAngle;
   servoVelocity += diff * SPRING_K;
@@ -74,8 +128,112 @@ void updateServo() {
   servoCurrentAngle += servoVelocity;
 
   // Convert to absolute servo position and clamp
-  int pos = (int)(SERVO_CENTER + servoCurrentAngle);
+  // chirpServoOffset adds real-time head kick during whistle
+  int pos = (int)(SERVO_CENTER + servoCurrentAngle + chirpServoOffset);
   pos = constrain(pos, SERVO_MIN, SERVO_MAX);
 
   servo.write(pos);
+}
+
+// ============================================================
+// CALIBRATION MODE
+// ============================================================
+// Bypasses spring physics — writes angles directly to servo.
+// Used during assembly to verify face orientation.
+
+void enterCalibration() {
+  calibrationMode = true;
+  calibrationStep = 0;
+  servoVelocity = 0;
+  servoOscillationAmp = 0;
+
+  servo.write(calibrationAngles[0]);
+  servoCurrentAngle = calibrationAngles[0] - SERVO_CENTER;
+  servoTargetAngle = servoCurrentAngle;
+
+  Serial.println("[cal] === CALIBRATION MODE ===");
+  Serial.println("[cal] Step 0: " + String(calibrationLabels[0]) + " -> " + String(calibrationAngles[0]) + " deg");
+  Serial.println("[cal] Press button to advance, or send S,<angle>");
+}
+
+void advanceCalibration() {
+  calibrationStep++;
+
+  if (calibrationStep >= CALIBRATION_STEPS) {
+    exitCalibration();
+    return;
+  }
+
+  int angle = calibrationAngles[calibrationStep];
+  servo.write(angle);
+  servoCurrentAngle = angle - SERVO_CENTER;
+  servoTargetAngle = servoCurrentAngle;
+  servoVelocity = 0;
+
+  Serial.println("[cal] Step " + String(calibrationStep) + ": " +
+                 String(calibrationLabels[calibrationStep]) + " -> " +
+                 String(angle) + " deg");
+
+  if (calibrationStep == CALIBRATION_STEPS - 1) {
+    Serial.println("[cal] (next press exits calibration)");
+  }
+}
+
+void exitCalibration() {
+  calibrationMode = false;
+  calibrationStep = 0;
+  servoVelocity = 0;
+  servoOscillationAmp = 0;
+
+  // Settle at center
+  servo.write(SERVO_CENTER);
+  servoCurrentAngle = 0;
+  servoTargetAngle = 0;
+
+  Serial.println("[cal] === EXITED CALIBRATION — back to normal ===");
+}
+
+void setServoAngleDirect(int angle) {
+  angle = constrain(angle, SERVO_MIN, SERVO_MAX);
+  servo.write(angle);
+  servoCurrentAngle = angle - SERVO_CENTER;
+  servoTargetAngle = servoCurrentAngle;
+  servoVelocity = 0;
+  servoOscillationAmp = 0;
+
+  Serial.println("[servo] Direct set: " + String(angle) + " deg (offset " +
+                 String(servoCurrentAngle, 1) + " from center)");
+}
+
+void snapToCenter() {
+  servo.write(SERVO_CENTER);
+  servoCurrentAngle = 0;
+  servoTargetAngle = 0;
+  servoVelocity = 0;
+  servoOscillationAmp = 0;
+  demoStep = 0;  // Reset demo cycle
+
+  if (calibrationMode) {
+    calibrationMode = false;
+    calibrationStep = 0;
+    Serial.println("[cal] Long press — snapped to CENTER, exited calibration");
+  } else {
+    Serial.println("[servo] Snapped to CENTER (" + String(SERVO_CENTER) + " deg)");
+  }
+}
+
+// ============================================================
+// DEMO PRESETS — cycle through canned emotions
+// ============================================================
+// Fires preset scores through the normal eval pipeline.
+// Button short-press or serial 'D' command.
+
+void triggerDemoPreset() {
+  latestScores = demoPresets[demoStep];
+  newEvalAvailable = true;
+
+  Serial.println("[demo] Preset " + String(demoStep) + ": " + String(demoLabels[demoStep]));
+  printEval(latestScores);
+
+  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
 }

--- a/firmware/rubber_duck/rubber_duck.ino
+++ b/firmware/rubber_duck/rubber_duck.ino
@@ -27,11 +27,22 @@
 EvalScores latestScores = {0, 0, 0, 0, 0, 'U', false};
 bool newEvalAvailable = false;
 
+// --- Permission State ---
+bool          permissionPending = false;
+unsigned long permissionStartTime = 0;
+unsigned long lastPermissionNag = 0;
+unsigned long nextNagInterval = 0;      // Randomized per-nag
+
 // --- Hardware ---
 PWMServo servo;
 
 // --- Timing ---
 unsigned long lastServoUpdate = 0;
+
+// --- Button State (for short/long press detection) ---
+bool     buttonDown       = false;
+unsigned long buttonDownAt = 0;
+#define LONG_PRESS_MS     2000   // Hold 2s for snap-to-center
 
 void setup() {
   Serial.begin(SERIAL_BAUD);
@@ -84,16 +95,43 @@ void loop() {
   // Check for incoming serial data
   readSerial();
 
-  // Check mode toggle button (sends MODE to widget via serial)
-  static unsigned long lastButtonPress = 0;
-  if (digitalRead(BUTTON_PIN) == LOW && (now - lastButtonPress) > BUTTON_DEBOUNCE_MS) {
-    lastButtonPress = now;
-    Serial.println("MODE");
+  // Button handling: short press = demo preset cycle, long press = snap to center
+  bool pressed = (digitalRead(BUTTON_PIN) == LOW);
+
+  if (pressed && !buttonDown) {
+    // Button just pressed down
+    buttonDown = true;
+    buttonDownAt = now;
+  }
+  else if (pressed && buttonDown) {
+    // Button held — check for long press
+    if ((now - buttonDownAt) >= LONG_PRESS_MS) {
+      snapToCenter();
+      buttonDown = false;  // Consume the press, don't fire short press on release
+    }
+  }
+  else if (!pressed && buttonDown) {
+    // Button released — short press if wasn't consumed by long press
+    buttonDown = false;
+    unsigned long held = now - buttonDownAt;
+
+    if (held < LONG_PRESS_MS && held > 50) {  // 50ms debounce floor
+      if (calibrationMode) {
+        advanceCalibration();
+      } else {
+        triggerDemoPreset();
+      }
+    }
   }
 
-  // Process new evaluation if available
-  if (newEvalAvailable) {
+  // Process new evaluation if available (skip during calibration)
+  if (newEvalAvailable && !calibrationMode) {
     newEvalAvailable = false;
+
+    // Any new eval means the session moved on — permission was handled
+    if (permissionPending) {
+      exitPermission();
+    }
 
     #if ENABLE_SERVO_DUCK
       ServoTarget target = servoReducer(latestScores);
@@ -120,9 +158,9 @@ void loop() {
     printEval(latestScores);
   }
 
-  // Fixed-rate updates
+  // Fixed-rate updates (skip spring physics during calibration)
   #if ENABLE_SERVO_DUCK
-  if (now - lastServoUpdate >= SERVO_UPDATE_MS) {
+  if (!calibrationMode && (now - lastServoUpdate >= SERVO_UPDATE_MS)) {
     lastServoUpdate = now;
     updateServo();
   }
@@ -134,6 +172,11 @@ void loop() {
     updateLEDs();
   }
   #endif
+
+  // Permission nag loop
+  if (permissionPending) {
+    updatePermissionNag(now);
+  }
 
   // I2S audio chirp update
   updateI2SAudio();
@@ -179,6 +222,45 @@ void startupAnimation() {
   #if ENABLE_I2S_AUDIO
     playStartupChirp();
   #endif
+}
+
+// --- Permission State Machine ---
+
+// Three-tier nag: urgent (4-8s) → lazy (15-30s) → rare (5-10min)
+void updatePermissionNag(unsigned long now) {
+  if ((now - lastPermissionNag) <= nextNagInterval) return;
+
+  lastPermissionNag = now;
+  unsigned long elapsed = now - permissionStartTime;
+
+  if (elapsed > PERMISSION_RARE_AT) {
+    nextNagInterval = PERMISSION_RARE_BASE + random(PERMISSION_RARE_JITTER);
+  } else if (elapsed > PERMISSION_BACKOFF_AT) {
+    nextNagInterval = PERMISSION_LAZY_BASE + random(PERMISSION_LAZY_JITTER);
+  } else {
+    nextNagInterval = PERMISSION_NAG_BASE + random(-PERMISSION_NAG_JITTER, PERMISSION_NAG_JITTER + 1);
+  }
+
+  #if ENABLE_I2S_AUDIO
+    playPermissionChirp();
+  #endif
+}
+
+void enterPermission() {
+  permissionPending = true;
+  permissionStartTime = millis();
+  lastPermissionNag = 0;  // Chirp immediately
+  Serial.println("[perm] === PERMISSION PENDING ===");
+
+  #if ENABLE_I2S_AUDIO
+    playPermissionChirp();
+  #endif
+}
+
+void exitPermission() {
+  permissionPending = false;
+  chirpServoOffset = 0.0;
+  Serial.println("[perm] === PERMISSION RESOLVED ===");
 }
 
 // --- Debug print ---

--- a/widget/Sources/RubberDuckWidget/ClaudeEvaluator.swift
+++ b/widget/Sources/RubberDuckWidget/ClaudeEvaluator.swift
@@ -63,7 +63,7 @@ actor ClaudeEvaluator {
         guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
             let status = (response as? HTTPURLResponse)?.statusCode ?? 0
             let body = String(data: data, encoding: .utf8) ?? ""
-            print("[eval] API error \(status): \(body.prefix(200))")
+            DuckLog.log("[eval] API error \(status): \(body.prefix(200))")
             return Self.fallbackScores()
         }
 
@@ -72,7 +72,7 @@ actor ClaudeEvaluator {
               let content = json["content"] as? [[String: Any]],
               let firstBlock = content.first,
               var raw = firstBlock["text"] as? String else {
-            print("[eval] Failed to extract text from API response")
+            DuckLog.log("[eval] Failed to extract text from API response")
             return Self.fallbackScores()
         }
 
@@ -92,7 +92,7 @@ actor ClaudeEvaluator {
         // Parse JSON scores
         guard let scoreData = raw.data(using: .utf8),
               let scoreDict = try? JSONSerialization.jsonObject(with: scoreData) as? [String: Any] else {
-            print("[eval] Failed to parse JSON: \(raw.prefix(200))")
+            DuckLog.log("[eval] Failed to parse JSON: \(raw.prefix(200))")
             return Self.fallbackScores()
         }
 

--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -30,6 +30,13 @@ class DuckCoordinator: ObservableObject {
         updateExpression()
         flashReaction()
 
+        // Any new eval means the session moved on — resolve permission if pending
+        // (Belt and suspenders: Teensy firmware also auto-resolves on new eval)
+        if evalService.permissionPending {
+            evalService.permissionPending = false
+        }
+        serialManager.sendCommand("P,0")
+
         // Send to Teensy via serial
         if let scores = evalService.scores {
             serialManager.sendScores(scores, source: evalService.source)
@@ -57,14 +64,30 @@ class DuckCoordinator: ObservableObject {
         speechService.speak(label)
     }
 
-    /// Called when permission state changes.
+    /// Called when a new permission request arrives.
     func handlePermissionChange() {
         updateExpression()
         if evalService.permissionPending {
+            serialManager.sendCommand("P,1")
             triggerPermissionWobble()
             speechService.askPermission(toolName: evalService.permissionTool,
                                         options: evalService.permissionOptions)
         }
+    }
+
+    /// Called when user approves/denies permission (voice or UI).
+    /// Direct path — doesn't depend on SwiftUI onChange.
+    func handlePermissionDecision(index: Int) {
+        evalService.sendPermissionDecision(index: index)
+        serialManager.sendCommand("P,0")
+        updateExpression()
+    }
+
+    /// Called when permission resolves (pending → false) via onChange.
+    /// Backup path in case decision comes from outside the widget.
+    func handlePermissionResolved() {
+        updateExpression()
+        serialManager.sendCommand("P,0")
     }
 
     // MARK: - Expression

--- a/widget/Sources/RubberDuckWidget/DuckLog.swift
+++ b/widget/Sources/RubberDuckWidget/DuckLog.swift
@@ -1,0 +1,33 @@
+// Duck Log — Unified logging to ~/Library/Logs/RubberDuck.log
+//
+// All components (server, evaluator, permission, etc.) log through this
+// so you can watch everything with: tail -f ~/Library/Logs/RubberDuck.log
+
+import Foundation
+
+enum DuckLog {
+    private static let logURL: URL = {
+        let logs = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs")
+        try? FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        return logs.appendingPathComponent("RubberDuck.log")
+    }()
+
+    /// Log a message to both stdout and the log file.
+    static func log(_ msg: String) {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let line = "[\(ts)] \(msg)\n"
+        print(line, terminator: "")
+        if let data = line.data(using: .utf8) {
+            if FileManager.default.fileExists(atPath: logURL.path) {
+                if let handle = try? FileHandle(forWritingTo: logURL) {
+                    handle.seekToEndOfFile()
+                    handle.write(data)
+                    handle.closeFile()
+                }
+            } else {
+                try? data.write(to: logURL)
+            }
+        }
+    }
+}

--- a/widget/Sources/RubberDuckWidget/DuckServer.swift
+++ b/widget/Sources/RubberDuckWidget/DuckServer.swift
@@ -103,7 +103,7 @@ class DuckServer: ObservableObject {
                     do {
                         scores = try await evaluator.evaluate(text: text, source: source, userContext: userContext)
                     } catch {
-                        print("[server] Eval error: \(error)")
+                        DuckLog.log("[server] Eval error: \(error)")
                         scores = EvalScores(
                             creativity: 0, soundness: 0, ambition: 0,
                             elegance: 0, risk: 0,
@@ -133,7 +133,7 @@ class DuckServer: ObservableObject {
                     }
 
                     // Log
-                    print("[\(source)] \(scores.reaction ?? "...")  |  \(scores.summary ?? "")  |  "
+                    DuckLog.log("[\(source)] \(scores.reaction ?? "...")  |  \(scores.summary ?? "")  |  "
                         + "cr:\(String(format: "%+.1f", scores.creativity)) "
                         + "sn:\(String(format: "%+.1f", scores.soundness)) "
                         + "am:\(String(format: "%+.1f", scores.ambition)) "
@@ -167,7 +167,7 @@ class DuckServer: ObservableObject {
 
                     let optionLabels = suggestions.map { PermissionGate.describeSuggestion($0) }
 
-                    print("[permission] Request: \(toolName) (\(suggestions.count) options)")
+                    DuckLog.log("[permission] Request: \(toolName) (\(suggestions.count) options)")
 
                     // Broadcast pending to WebSocket clients
                     let pendingEvent = PermissionEvent(
@@ -188,7 +188,7 @@ class DuckServer: ObservableObject {
                     let (decision, suggestionIndex) = await permissionGate.waitForDecision()
 
                     if decision == "timeout" {
-                        print("[permission] Timeout — no response from widget")
+                        DuckLog.log("[permission] Timeout — no response")
                         let timeoutEvent = PermissionEvent(
                             type: "permission", status: "timeout",
                             toolName: toolName, toolInput: nil, optionLabels: nil
@@ -317,7 +317,10 @@ class DuckServer: ObservableObject {
 
                 let app = Application(
                     router: router,
-                    server: .http1WebSocketUpgrade(webSocketRouter: router),
+                    server: .http1WebSocketUpgrade(
+                        webSocketRouter: router,
+                        configuration: .init(autoPing: .disabled)
+                    ),
                     configuration: .init(
                         address: .hostname("127.0.0.1", port: port),
                         serverName: "RubberDuck"
@@ -325,18 +328,14 @@ class DuckServer: ObservableObject {
                     logger: logger
                 )
 
-                print("=" * 50)
-                print("  RUBBER DUCK — Evaluation Service (Swift)")
-                print("  Dashboard:  http://localhost:\(port)")
-                print("  3D Viewer:  http://localhost:\(port)/viewer")
-                print("=" * 50)
+                DuckLog.log("[server] Started on http://localhost:\(port)")
 
                 await setRunning(true)
 
                 try await app.run()
 
             } catch {
-                print("[server] Failed to start: \(error)")
+                DuckLog.log("[server] Failed to start: \(error)")
                 await setRunning(false)
             }
         }
@@ -346,7 +345,7 @@ class DuckServer: ObservableObject {
         serverTask?.cancel()
         serverTask = nil
         isRunning = false
-        print("[server] Stopped")
+        DuckLog.log("[server] Stopped")
     }
 }
 

--- a/widget/Sources/RubberDuckWidget/DuckView.swift
+++ b/widget/Sources/RubberDuckWidget/DuckView.swift
@@ -98,6 +98,11 @@ struct DuckView: View {
         .onChange(of: evalService.permissionRequestId) {
             coordinator.handlePermissionChange()
         }
+        .onChange(of: evalService.permissionPending) {
+            if !evalService.permissionPending {
+                coordinator.handlePermissionResolved()
+            }
+        }
     }
 
     // MARK: - Duck Body

--- a/widget/Sources/RubberDuckWidget/PermissionGate.swift
+++ b/widget/Sources/RubberDuckWidget/PermissionGate.swift
@@ -33,7 +33,7 @@ actor PermissionGate {
     /// Called when the widget sends a permission response via WebSocket or local transport.
     func resolve(decision: String, suggestionIndex: Int? = nil) {
         let validDecision = (decision == "allow" || decision == "deny") ? decision : "deny"
-        print("[permission] Resolved: \(validDecision), suggestion_index=\(String(describing: suggestionIndex))")
+        DuckLog.log("[permission] Resolved: \(validDecision), suggestion_index=\(String(describing: suggestionIndex))")
 
         timeoutTask?.cancel()
         timeoutTask = nil
@@ -61,7 +61,7 @@ actor PermissionGate {
 
     private func handleTimeout() {
         guard let cont = continuation else { return }
-        print("[permission] Timeout — no response from widget")
+        DuckLog.log("[permission] Timeout — no response from widget")
         continuation = nil
         timeoutTask = nil
         cont.resume(returning: ("timeout", nil))

--- a/widget/Sources/RubberDuckWidget/PermissionGate.swift
+++ b/widget/Sources/RubberDuckWidget/PermissionGate.swift
@@ -2,29 +2,40 @@
 //
 // Port of service/permission.py. Uses CheckedContinuation for async blocking
 // until the widget sends a voice response (allow/deny).
+//
+// Timeout uses DispatchQueue instead of Task.sleep to avoid the
+// swift_task_dealloc crash that occurs with Task.sleep(for:) in
+// certain actor/continuation contexts.
 
 import Foundation
 
 actor PermissionGate {
 
     private var continuation: CheckedContinuation<(String, Int?), Never>?
-    private var timeoutTask: Task<Void, Never>?
+    private var timeoutWorkItem: DispatchWorkItem?
 
     // MARK: - Wait / Resolve
 
     /// Block until the widget sends a permission response, or timeout.
     /// Returns (decision, suggestionIndex) where decision is "allow", "deny", or "timeout".
-    func waitForDecision(timeout: Duration = .seconds(30)) async -> (String, Int?) {
+    func waitForDecision(timeoutSeconds: Double = 30.0) async -> (String, Int?) {
         // Cancel any stale pending request
-        timeoutTask?.cancel()
-        timeoutTask = nil
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
         if let old = continuation {
             continuation = nil
             old.resume(returning: ("timeout", nil))
         }
 
         let result = await withCheckedContinuation { (cont: CheckedContinuation<(String, Int?), Never>) in
-            self.storeContinuationAndStartTimeout(cont, timeout: timeout)
+            continuation = cont
+
+            // Use GCD for timeout — avoids swift_task_dealloc crash from Task.sleep
+            let workItem = DispatchWorkItem { [weak self] in
+                Task { await self?.handleTimeout() }
+            }
+            timeoutWorkItem = workItem
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: workItem)
         }
 
         return result
@@ -35,8 +46,8 @@ actor PermissionGate {
         let validDecision = (decision == "allow" || decision == "deny") ? decision : "deny"
         DuckLog.log("[permission] Resolved: \(validDecision), suggestion_index=\(String(describing: suggestionIndex))")
 
-        timeoutTask?.cancel()
-        timeoutTask = nil
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
 
         if let cont = continuation {
             continuation = nil
@@ -44,26 +55,11 @@ actor PermissionGate {
         }
     }
 
-    /// Store continuation and launch a detached timeout task.
-    /// Using Task.detached avoids inheriting the suspended parent task context,
-    /// which prevents the swift_task_dealloc crash that occurs with Task { }.
-    private func storeContinuationAndStartTimeout(
-        _ cont: CheckedContinuation<(String, Int?), Never>,
-        timeout: Duration
-    ) {
-        continuation = cont
-        timeoutTask = Task.detached { [weak self] in
-            try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled else { return }
-            await self?.handleTimeout()
-        }
-    }
-
     private func handleTimeout() {
         guard let cont = continuation else { return }
         DuckLog.log("[permission] Timeout — no response from widget")
         continuation = nil
-        timeoutTask = nil
+        timeoutWorkItem = nil
         cont.resume(returning: ("timeout", nil))
     }
 

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -70,9 +70,9 @@ struct RubberDuckWidgetApp: App {
             evalService?.sendVoiceInput(text)
         }
 
-        // Permission response → send to service → unblock hook
-        speechService.onPermissionResponse = { [weak evalService] index in
-            evalService?.sendPermissionDecision(index: index)
+        // Permission response → send to service → unblock hook → tell Teensy
+        speechService.onPermissionResponse = { [weak coordinator] index in
+            coordinator?.handlePermissionDecision(index: index)
         }
 
         // Wake word → duck acknowledges

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -77,13 +77,13 @@ struct RubberDuckWidgetApp: App {
 
         // Wake word → duck acknowledges
         speechService.onWakeWord = { [weak speechService] in
-            print("[app] Wake word detected")
+            DuckLog.log("[app] Wake word detected")
             _ = speechService // retain
         }
 
         // Teensy serial → log incoming messages
         serialManager.onLineReceived = { line in
-            print("[serial] \(line)")
+            DuckLog.log("[serial] \(line)")
         }
 
         // Teensy mode button → toggle coordinator mode
@@ -101,7 +101,7 @@ struct RubberDuckWidgetApp: App {
                     return
                 }
             }
-            print("[app] Permissions not granted after 10s. Use right-click → Start Listening.")
+            DuckLog.log("[app] Permissions not granted after 10s. Use right-click → Start Listening.")
         }
     }
 }


### PR DESCRIPTION
## Summary
- **Demo emotion presets** — button cycles through 6 canned reactions (Impressed → Bored), each firing full servo + chirp expression
- **Chirp engine refactor** — extracted `hillEnvelope()`, `startChirp()` helpers, added explicit filter tracking flag, removed dead code
- **Idle heartbeat** — gentle ±5° random drift via spring physics when duck is at rest (configurable timing/range)
- **Permission nag wiring** — widget sends P,1/P,0 to Teensy, three independent resolution paths (voice approval, onChange backup, new-eval safety net)
- **Doc updates** — rewrote Phase 2 hardware handoff for current CSV protocol + expression system, updated TODO

## Test plan
- [ ] Flash firmware, press button — cycles through 6 presets with distinct servo angles + chirps
- [ ] Long-press (2s) snaps to center, resets to preset 0
- [ ] Serial `D` command does the same as button press
- [ ] Duck drifts gently at idle (±5° hops every 3-8s)
- [ ] Trigger permission (`P,1`) — duck chirps uh-oh and nags with backoff
- [ ] Approve permission — duck stops nagging immediately (no lingering uh-oh)
- [ ] Serial `CAL` still enters calibration mode

🦆 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)