### PR TITLE
Refactor: centralize mode/sentiment logic, fix TTSGate thread safety

### DIFF
--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -98,7 +98,7 @@ class DuckCoordinator: ObservableObject {
             serialManager.sendScores(scores, source: evalService.source)
         }
 
-        // Speak based on current mode
+        // Speak based on current mode (permissionsOnly exits early above)
         // Relay mode: only speak Claude's output, not the user's (you know what you said)
         let textToSpeak: String
         switch mode {
@@ -107,7 +107,7 @@ class DuckCoordinator: ObservableObject {
         case .relay:
             textToSpeak = isUserEval ? "" : evalService.summary
         case .permissionsOnly:
-            textToSpeak = ""  // unreachable — early return above
+            textToSpeak = ""  // unreachable — early return above; kept for exhaustive switch
         }
         if !textToSpeak.isEmpty {
             // Wildcard mode: AI-picked voice per utterance (fall back to Superstar if no key)
@@ -135,13 +135,6 @@ class DuckCoordinator: ObservableObject {
         mode = newMode
         DuckConfig.duckMode = newMode
 
-        let label: String
-        switch mode {
-        case .critic: label = "Critic mode"
-        case .relay: label = "Relay mode"
-        case .permissionsOnly: label = "Permissions only"
-        }
-
         // In permissions-only, force mic to permissionsOnly listen mode + reset face to neutral
         if mode == .permissionsOnly {
             speechService.listenMode = .permissionsOnly
@@ -153,7 +146,7 @@ class DuckCoordinator: ObservableObject {
         // Clear any thinking state when switching modes
         clearThinking()
 
-        speechService.speak(label)
+        speechService.speak(mode.spokenLabel)
     }
 
     /// Clean up thinking state (called on turn-off).

--- a/widget/Sources/RubberDuckWidget/DuckProtocol.swift
+++ b/widget/Sources/RubberDuckWidget/DuckProtocol.swift
@@ -17,6 +17,12 @@ struct EvalScores: Codable, Equatable {
     let reaction: String?
     let summary: String?      // Factual summary (relay mode)
     var voice: String?        // Wildcard voice key (AI-picked, Haiku only for now)
+
+    /// Weighted sentiment score combining all dimensions.
+    /// Positive = good code, negative = concerning code.
+    var sentiment: Double {
+        soundness * 0.3 + elegance * 0.25 + creativity * 0.2 + ambition * 0.15 - risk * 0.1
+    }
 }
 
 // MARK: - Enums
@@ -38,6 +44,42 @@ enum DuckMode: String, CaseIterable {
     case permissionsOnly  // Silent watchdog — only voice-confirmed permissions (default)
     case critic           // Speak opinionated reaction
     case relay            // Speak factual summary
+
+    /// Human-readable label for menus and TTS.
+    var label: String {
+        switch self {
+        case .permissionsOnly: return "Permissions Only"
+        case .critic: return "Critic Mode"
+        case .relay: return "Relay Mode"
+        }
+    }
+
+    /// SF Symbol name for this mode.
+    var iconName: String {
+        switch self {
+        case .permissionsOnly: return "lock.shield"
+        case .critic: return "eyeglasses"
+        case .relay: return "phone.fill"
+        }
+    }
+
+    /// Short subtitle for menu items.
+    var subtitle: String {
+        switch self {
+        case .permissionsOnly: return "Silent watchdog — voice permissions only"
+        case .critic: return "Inner monologue and alerts"
+        case .relay: return "Walkie talkie with Claude"
+        }
+    }
+
+    /// TTS-friendly label (no "Mode" suffix).
+    var spokenLabel: String {
+        switch self {
+        case .permissionsOnly: return "Permissions only"
+        case .critic: return "Critic mode"
+        case .relay: return "Relay mode"
+        }
+    }
 }
 
 // MARK: - Inbound Messages (service → widget via WebSocket)

--- a/widget/Sources/RubberDuckWidget/DuckView.swift
+++ b/widget/Sources/RubberDuckWidget/DuckView.swift
@@ -248,21 +248,7 @@ struct DuckView: View {
                 Label("Relay Mode", systemImage: "phone.fill")
             }
         } label: {
-            let modeLabel: String = {
-                switch coordinator.mode {
-                case .critic: return "Critic Mode"
-                case .relay: return "Relay Mode"
-                case .permissionsOnly: return "Permissions Only"
-                }
-            }()
-            let modeIcon: String = {
-                switch coordinator.mode {
-                case .critic: return "eyeglasses"
-                case .relay: return "phone.fill"
-                case .permissionsOnly: return "lock.shield"
-                }
-            }()
-            Label(modeLabel, systemImage: modeIcon)
+            Label(coordinator.mode.label, systemImage: coordinator.mode.iconName)
         }
 
         // Voice
@@ -285,9 +271,7 @@ struct DuckView: View {
         } label: {
             Label(
                 "Voice: \(speechService.listenMode.label)",
-                systemImage: speechService.listenMode == .off ? "microphone.slash.fill"
-                    : speechService.listenMode == .permissionsOnly ? "microphone.badge.xmark"
-                    : "microphone.fill"
+                systemImage: speechService.listenMode.iconName
             )
         }
 

--- a/widget/Sources/RubberDuckWidget/EvalService.swift
+++ b/widget/Sources/RubberDuckWidget/EvalService.swift
@@ -60,14 +60,7 @@ class EvalService: ObservableObject {
             summary = newScores.summary ?? ""
             source = result.source ?? ""
             evalCount += 1
-
-            sentiment = (
-                newScores.soundness * 0.3 +
-                newScores.elegance * 0.25 +
-                newScores.creativity * 0.2 +
-                newScores.ambition * 0.15 -
-                newScores.risk * 0.1
-            )
+            sentiment = newScores.sentiment
 
         case .permission(let event):
             permissionTool = event.toolName ?? "unknown"
@@ -91,9 +84,18 @@ class EvalService: ObservableObject {
     }
 
     func sendPermissionDecision(index: Int) {
+        // Bounds check: suggestion index must be within available options (1-based)
+        let clampedIndex: Int
+        if index > 0 && index > permissionOptions.count {
+            DuckLog.log("[eval] Warning: suggestion index \(index) out of bounds (\(permissionOptions.count) options), clamping to allow")
+            clampedIndex = 0  // Fall back to simple allow
+        } else {
+            clampedIndex = index
+        }
+
         let cmd = PermissionResponseCommand(
-            decision: index >= 0 ? "allow" : "deny",
-            suggestionIndex: index > 0 ? index : nil
+            decision: clampedIndex >= 0 ? "allow" : "deny",
+            suggestionIndex: clampedIndex > 0 ? clampedIndex : nil
         )
         transport.send(.permissionResponse(cmd))
         permissionPending = false

--- a/widget/Sources/RubberDuckWidget/ExpressionEngine.swift
+++ b/widget/Sources/RubberDuckWidget/ExpressionEngine.swift
@@ -42,13 +42,7 @@ enum ExpressionEngine {
         }
 
         // --- Sentiment → body warmth + glow ---
-        let sentiment = (
-            s.soundness * 0.3 +
-            s.elegance * 0.25 +
-            s.creativity * 0.2 +
-            s.ambition * 0.15 -
-            s.risk * 0.1
-        )
+        let sentiment = s.sentiment
 
         // Positive = warmer (toward orange), negative = cooler (toward green)
         // Negate because hueRotation positive = green, negative = orange

--- a/widget/Sources/RubberDuckWidget/SpeechService.swift
+++ b/widget/Sources/RubberDuckWidget/SpeechService.swift
@@ -27,6 +27,15 @@ enum ListenMode: Int, CaseIterable {
         }
     }
 
+    /// SF Symbol name for this listen mode.
+    var iconName: String {
+        switch self {
+        case .off: return "microphone.slash.fill"
+        case .permissionsOnly: return "microphone.badge.xmark"
+        case .active: return "microphone.fill"
+        }
+    }
+
     /// Cycle to the next mode.
     var next: ListenMode {
         ListenMode(rawValue: (rawValue + 1) % ListenMode.allCases.count) ?? .off

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -95,37 +95,24 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         menu.addItem(.separator())
 
         // --- Mode submenu ---
-        let modeLabel: String
-        let modeIcon: String
-        switch coordinator.mode {
-        case .critic: modeLabel = "Critic Mode"; modeIcon = "eyeglasses"
-        case .relay: modeLabel = "Relay Mode"; modeIcon = "phone.fill"
-        case .permissionsOnly: modeLabel = "Permissions Only"; modeIcon = "lock.shield"
-        }
-        let modeItem = NSMenuItem(title: modeLabel, action: nil, keyEquivalent: "")
-        modeItem.image = NSImage(systemSymbolName: modeIcon, accessibilityDescription: modeLabel)
+        let currentMode = coordinator.mode
+        let modeItem = NSMenuItem(title: currentMode.label, action: nil, keyEquivalent: "")
+        modeItem.image = NSImage(systemSymbolName: currentMode.iconName, accessibilityDescription: currentMode.label)
         let modeMenu = NSMenu()
 
-        let permItem = NSMenuItem(title: "Permissions Only", action: #selector(setModePermissions), keyEquivalent: "")
-        permItem.target = self
-        permItem.state = coordinator.mode == .permissionsOnly ? .on : .off
-        permItem.image = NSImage(systemSymbolName: "lock.shield", accessibilityDescription: "Permissions only")
-        permItem.subtitle = "Silent watchdog — voice permissions only"
-        modeMenu.addItem(permItem)
-
-        let criticItem = NSMenuItem(title: "Critic", action: #selector(setModeCritic), keyEquivalent: "")
-        criticItem.target = self
-        criticItem.state = coordinator.mode == .critic ? .on : .off
-        criticItem.image = NSImage(systemSymbolName: "eyeglasses", accessibilityDescription: "Critic mode")
-        criticItem.subtitle = "Inner monologue and alerts"
-        modeMenu.addItem(criticItem)
-
-        let relayItem = NSMenuItem(title: "Relay", action: #selector(setModeRelay), keyEquivalent: "")
-        relayItem.target = self
-        relayItem.state = coordinator.mode == .relay ? .on : .off
-        relayItem.image = NSImage(systemSymbolName: "phone.fill", accessibilityDescription: "Relay mode")
-        relayItem.subtitle = "Walkie talkie with Claude"
-        modeMenu.addItem(relayItem)
+        let modeActions: [(DuckMode, Selector)] = [
+            (.permissionsOnly, #selector(setModePermissions)),
+            (.critic, #selector(setModeCritic)),
+            (.relay, #selector(setModeRelay)),
+        ]
+        for (mode, action) in modeActions {
+            let item = NSMenuItem(title: mode.label, action: action, keyEquivalent: "")
+            item.target = self
+            item.state = currentMode == mode ? .on : .off
+            item.image = NSImage(systemSymbolName: mode.iconName, accessibilityDescription: mode.label)
+            item.subtitle = mode.subtitle
+            modeMenu.addItem(item)
+        }
 
         modeItem.submenu = modeMenu
         menu.addItem(modeItem)
@@ -202,31 +189,17 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         menu.addItem(voiceItem)
 
         // --- Mic submenu ---
-        let micLabel = speechService.listenMode.label
-        let micIcon: String = {
-            switch speechService.listenMode {
-            case .off: return "microphone.slash.fill"
-            case .permissionsOnly: return "microphone.badge.xmark"
-            case .active: return "microphone.fill"
-            }
-        }()
-        let micItem = NSMenuItem(title: "Mic: \(micLabel)", action: nil, keyEquivalent: "")
-        micItem.image = NSImage(systemSymbolName: micIcon, accessibilityDescription: micLabel)
+        let currentListenMode = speechService.listenMode
+        let micItem = NSMenuItem(title: "Mic: \(currentListenMode.label)", action: nil, keyEquivalent: "")
+        micItem.image = NSImage(systemSymbolName: currentListenMode.iconName, accessibilityDescription: currentListenMode.label)
         let micMenu = NSMenu()
 
-        let listenModeIcons: [ListenMode: String] = [
-            .off: "microphone.slash.fill",
-            .permissionsOnly: "microphone.badge.xmark",
-            .active: "microphone.fill",
-        ]
         for mode in ListenMode.allCases {
             let listenItem = NSMenuItem(title: mode.label, action: #selector(setListenMode(_:)), keyEquivalent: "")
             listenItem.target = self
             listenItem.tag = mode.rawValue
-            listenItem.state = speechService.listenMode == mode ? .on : .off
-            if let iconName = listenModeIcons[mode] {
-                listenItem.image = NSImage(systemSymbolName: iconName, accessibilityDescription: mode.label)
-            }
+            listenItem.state = currentListenMode == mode ? .on : .off
+            listenItem.image = NSImage(systemSymbolName: mode.iconName, accessibilityDescription: mode.label)
             if mode == .active {
                 listenItem.subtitle = "Use wake word \"Ducky\""
             }

--- a/widget/Sources/RubberDuckWidget/TTSEngine.swift
+++ b/widget/Sources/RubberDuckWidget/TTSEngine.swift
@@ -8,8 +8,23 @@ import Foundation
 
 /// Thread-safe mute flag — accessed from both MainActor and the audio render thread.
 /// Separate class (not actor-isolated) so the STTEngine's audio tap can read it directly.
+/// Uses os_unfair_lock for atomic read/write across threads.
 class TTSGate: @unchecked Sendable {
-    var muted = false
+    private var _muted = false
+    private var _lock = os_unfair_lock()
+
+    var muted: Bool {
+        get {
+            os_unfair_lock_lock(&_lock)
+            defer { os_unfair_lock_unlock(&_lock) }
+            return _muted
+        }
+        set {
+            os_unfair_lock_lock(&_lock)
+            _muted = newValue
+            os_unfair_lock_unlock(&_lock)
+        }
+    }
 }
 
 @MainActor


### PR DESCRIPTION
- TTSGate: wrap muted bool with os_unfair_lock for atomic cross-thread access
- EvalScores.sentiment: computed property replaces duplicate formula in EvalService and ExpressionEngine
- DuckMode extension: label, iconName, subtitle, spokenLabel replace 4 separate switch blocks across Coordinator, StatusBarManager, DuckView
- ListenMode.iconName: replaces duplicated icon dictionaries and ternaries
- StatusBarManager: data-driven mode menu loop replaces hand-built items
- EvalService: bounds check on permission suggestion index