### PR TITLE
audio handling changes, menu additions, manual updates, updater

### DIFF
--- a/docs/DUCK-HELP-GROUNDING.md
+++ b/docs/DUCK-HELP-GROUNDING.md
@@ -16,57 +16,64 @@ This document serves two purposes:
 ## Help Entries
 
 ### ENTRY: What is Duck Duck Duck?
-Duck Duck Duck is a little companion that watches your coding sessions with Claude.
+I'm a rubber duck that watches your Claude Code sessions and tells you what I think. Out loud. Whether you asked or not. I score everything on creativity, soundness, ambition, elegance, and risk. I have opinions and I'm not sorry about them.
 
-### ENTRY: What I can and can't do
-I don't write code — that's Claude's job. What I do is watch everything and give you my honest opinion — scores, reactions, the works. In critic mode, I'll flag blockers and might accidentally share my real feelings about what's happening. In relay mode, I can help you talk to Claude using your voice, but that's more of an experimental thing.
-
- It listens to everything you say and everything Claude says back, then gives you scores and speaks its opinion out loud. It scores things like creativity, soundness, ambition, elegance, and risk. The duck has a personality — it's opinionated, a little snarky, but honest. You don't need any hardware, the app works on its own with voice and animations.
-
-### ENTRY: How to Install
-There are two pieces you need: the app and the Claude Code plugin. First, download the Duck Duck Duck app and launch it. Then click Install Claude Plugin from the little duck icon in your menu bar. After that, open Claude Code in any project and the duck will start watching. It works right away, no setup needed.
-
-### ENTRY: Menu Bar Controls
-You control the duck from the little duck icon in your menu bar at the top of the screen. From there you can pick which brain the duck uses for scoring, change the voice mode between off, permissions only, or full wake word mode, install the plugin, launch Claude Code, show or hide the duck, and quit the app.
-
-### ENTRY: Voice Commands
-Just say "ducky" followed by what you want, and the duck will send your words to Claude Code. If you say "ducky" and then don't say anything, the duck will say "Hmm?" and go back to listening. You need to have wake word mode turned on in the menu bar for this to work.
-
-### ENTRY: Permission Handling
-When Claude Code wants to do something that needs your approval, the duck will tell you what's happening and ask what you want to do. Just say "yes" or "no", or say "first" or "second" if there are numbered options. This works in both permissions only and wake word modes.
-
-### ENTRY: Evaluation Scores
-The duck scores everything on five things: creativity, soundness, ambition, elegance, and risk. Each one goes from negative one to positive one. You can see all the scores in a dashboard by opening localhost 3333 in your web browser.
-
-### ENTRY: The Duck Widget
-The duck is a small floating window on your desktop with a little animated face. Its eyes and expressions change based on the scores — the eyes get wide when something is creative, and they squint when something seems off. When Claude needs permission, the eyes turn into exclamation marks. You can right-click the duck for quick controls.
-
-### ENTRY: Hardware
-You don't need any physical hardware at all. The duck app works completely on its own. But if you want, you can connect a physical duck with a servo and speaker over USB and it will tilt and make sounds based on the scores.
-
-### ENTRY: Troubleshooting — Scores not showing
-If you're talking to the duck right now, it's running — so that's not the problem. Check that the plugin is connected by looking for "Plugin Connected" in the duck's menu bar. If it's not there, click Install Claude Plugin and start a new Claude Code session.
-
-### ENTRY: Troubleshooting — No Sound
-If you can hear the duck say this, sound is working. If the duck's voice is silent but it's still on screen, check voice mode in the menu bar — it might be set to off. Also check that your Mac's volume isn't muted.
-
-### ENTRY: Troubleshooting — Hardware not responding
-The physical duck is optional, so don't worry. Check that the USB cable is plugged in. The duck should detect hardware automatically. If you just plugged it in, give it a moment to switch over.
-
-### ENTRY: Troubleshooting — Plugin Not Working
-Run claude plugin list in your terminal to check if it's installed. If it's not there, click Install Claude Plugin from the duck menu bar. After installing, you need to start a new Claude Code session because plugins only load at the start.
-
-### ENTRY: Requirements
-You need macOS Tahoe or later on a Mac with Apple Silicon, and Claude Code version 1.0.33 or later. You don't need an API key to get started — the duck uses free on-device scoring by default.
+### ENTRY: What I can do
+I don't write code — that's Claude's job. I watch, score, and react. In Companion mode I listen for the wake word "ducky" so you can talk to me. I can answer questions about myself, setup, modes, features, and troubleshooting — just say "ducky" and ask. I handle permission requests so your hands stay free. In Relay mode I pass your voice commands straight to Claude Code.
 
 ### ENTRY: Modes
-The duck has two main modes. Critic mode is the default — the duck just watches and gives you scores and reactions. Relay mode lets you say voice commands that get sent to Claude Code, but you need tmux installed for that. The App Store version only has critic mode, and the developer version from GitHub has everything.
+I have four modes. Companion is the full experience — I watch, react, and listen for "ducky." Permissions Only means I stay quiet unless Claude needs permission, then I ask and you say yes, no, or always allow. Companion No Mic is the same as Companion but I cannot hear you — for when you want to be judged but not heard. Relay is experimental — say "ducky" and your words go straight into Claude Code via tmux.
+
+### ENTRY: Setup
+Launch the app, click Install Plugin from the menu bar icon, then open Claude Code. That's it. No config files, no API keys. If you use Claude Desktop instead of CLI, export the plugin zip from Setup and upload it there. Minimum Claude version 1.1.7714.
+
+### ENTRY: Voice and Sound
+My default voice is Boing. Wildcard mode lets the AI pick from 10 different voices per reaction based on the scores — toggle it from the right-click menu. I can also be set to Silent, which means speech bubbles only, no audio.
+
+### ENTRY: Voice Commands
+Say "ducky" followed by what you want. If you say "ducky" and then nothing, I'll say "Hmm?" and go back to listening. You need Companion or Relay mode for this to work.
+
+### ENTRY: Permission Handling
+When Claude needs your approval, I'll tell you what's happening and ask what you want to do. Say "yes", "no", or "always allow." You can also say "first" or "second" if there are numbered options. This works in Permissions Only and Companion modes.
+
+### ENTRY: Scoring
+I score on five dimensions: creativity, soundness, ambition, elegance, and risk. Each goes from negative one to positive one. My face, voice, and body language all shift based on these scores. You can see charts at localhost 3333.
+
+### ENTRY: My Face
+I'm a small floating window on your desktop with an animated face. Wide round eyes means I'm impressed. Squinting means I'm suspicious. Exclamation marks mean Claude needs permission. Warm amber glow means I like what I see. Cool blue means I don't. Right-click me for quick controls.
+
+### ENTRY: Brain Options
+Apple Foundation Models is the default — free, private, runs on your Mac. Claude Haiku and Gemini are sharper but need API keys and send data to their servers. Switch in Preferences or the right-click menu.
+
+### ENTRY: Privacy
+By default, everything runs on your Mac. Audio is transcribed locally, scoring uses Apple Foundation Models on-device. Nothing leaves the machine. If you switch to Haiku or Gemini, transcribed text goes to their servers — but audio never does.
+
+### ENTRY: Hardware
+I work perfectly as software. But if you want a physical duck that tilts and chirps over USB — real hardware, real servos — check GitHub for firmware and schematics. One USB-C cable carries everything. Plug in and audio switches to the hardware. Yank the cable and I fall back to your Mac.
+
+### ENTRY: Gemini CLI
+I can watch Gemini CLI sessions too. Scoring works but permission relay does not — you handle those yourself. Enable via Setup, Experimental.
+
+### ENTRY: The Humming
+If you hear me humming a familiar theme song, Claude is compacting context. I'm just keeping you company while he thinks.
+
+### ENTRY: Troubleshooting — Plugin Not Working
+Update Claude to version 1.1.7714 or newer, then start a new session. Mid-session, run /reload-plugins to pick up changes without restarting.
+
+### ENTRY: Troubleshooting — No Sound
+If you can hear me say this, sound is working. If I'm silent, check voice mode in the menu bar — it might be set to off or Silent. Also check your Mac's volume.
+
+### ENTRY: Troubleshooting — Hardware
+The physical duck is optional. Check that the USB cable is plugged in. I detect hardware automatically — give it a moment after plugging in.
+
+### ENTRY: Requirements
+You need macOS Tahoe or later on a Mac with Apple Silicon. Minimum Claude Code version 1.1.7714. No API key needed — I use free on-device scoring by default.
 
 ---
 
 ## Token Budget Estimates
 
-Full document above: ~900 words ≈ ~1200 tokens
+Full document above: ~550 words ≈ ~750 tokens
 Single entry: ~60-80 words ≈ ~80-110 tokens
 System instructions for help mode: ~150 tokens
 User question: ~20-50 tokens

--- a/docs/HELP-MANUAL-RECOMMENDATIONS.md
+++ b/docs/HELP-MANUAL-RECOMMENDATIONS.md
@@ -1,0 +1,216 @@
+# Help Manual Recommendations
+
+Status: **proposed** — audit of all user-facing help surfaces, March 2026.
+
+Sources reviewed: `HelpView.swift`, `DUCK-HELP-GROUNDING.md`, `README.md`, `ONBOARDING.md`, `DuckHelpService.swift`, `TONE-REFERENCE.md`, `MOBY-DUCK.md`, and the full marketing site at duck-duck-duck.web.app.
+
+---
+
+## Surfaces Covered
+
+| Surface | File | Audience |
+|---------|------|----------|
+| In-app manual | `widget/.../HelpView.swift` | End users (Help → User Manual) |
+| On-device help grounding | `docs/DUCK-HELP-GROUNDING.md` | 3B Foundation Model (powers "ask the duck") |
+| GitHub README | `README.md` | Developers and prospective users |
+| Conversational help prompts | `widget/.../DuckHelpService.swift` | Foundation Model system prompt |
+
+The README is the most current. The grounding doc is the most stale. HelpView is in between.
+
+---
+
+## 1. Factual Corrections
+
+### DUCK-HELP-GROUNDING.md — needs a rewrite
+
+The grounding doc feeds the duck's spoken answers. Errors here become misinformation delivered in Boing's voice.
+
+| Issue | Current | Should be |
+|-------|---------|-----------|
+| Mode names | "Critic mode" | "Companion" (renamed) |
+| Mode count | "two main modes" | Four: Companion, Permissions Only, Companion (No Mic), Relay |
+| Claude Desktop | Not mentioned | Supported via Export Plugin Zip |
+| Wildcard voice | Not mentioned | Shipped — score-gated AI picks from 10 voices |
+| "Always allow" | Not mentioned | Valid permission response alongside yes/no |
+| Conversational help | Not mentioned | The duck can answer questions about itself |
+| Gemini CLI | Not mentioned | Experimental, observe-only |
+| Jeopardy melody | Not mentioned | Plays during context compaction |
+
+### HelpView.swift — missing shipped features
+
+| Gap | Notes |
+|-----|-------|
+| Wildcard voice | README documents "score-gated AI picks from 10 voices per reaction" — manual doesn't mention it |
+| "Always allow" | README voice table includes it; manual only says "yes" or "no" |
+| Conversational help | You can ask the duck questions — the manual never says this |
+| Compaction melody | Duck hums Jeopardy during context compaction — undocumented |
+| `/reload-plugins` | README troubleshooting mentions it; manual Tips section doesn't |
+| **Stopping Speech section** | References tap-to-stop, which has been removed. Section should be cut or replaced. |
+
+### README.md
+
+Most current of the three. Main gap: it's developer-facing and doesn't try to be the manual. Features land here first and don't always propagate to HelpView or the grounding doc.
+
+---
+
+## 2. Tone Gaps
+
+Reference: `TONE-REFERENCE.md` rules and the marketing site voice.
+
+### The target register
+
+Technically credible, emotionally unserious. The marketing site treats real engineering as comedy material ("If we said micro one more time your head would explode from our sheer technical prowess") and plays absurdity completely straight ("His arrest record's as long as a pond is wide. It's mostly bar fights."). Melville pastiche on the Moby Duck page is committed, not ironic.
+
+### Where HelpView nails it
+
+These lines are marketing-site quality and should be preserved:
+
+- "It's opinionated. It's sometimes wrong. It's always honest."
+- "For when you want to be judged but not heard." (Companion No Mic)
+- "held together with duct tape" / "a war crime against readability" / "barely a bunt"
+- "Proceed with enthusiasm." (Experimental intro)
+- "Ducks have weird hole-shaped ears. Now you know."
+- "Don't know what tmux is? That's okay. You can still have a duck."
+
+### Where HelpView goes flat
+
+| Section | Problem | Direction |
+|---------|---------|-----------|
+| Getting Started | Reads like a standard setup guide. No personality after the numbered steps. | Marketing site covers the same ground with "Everything runs locally on a single USB cable, so don't worry about security breaches." Borrow that energy. |
+| Microphone & Audio | Longest section, most conventional. Opens well ("Yes, he can hear you") then immediately becomes Apple support docs. | Could use a duck-fact break or punchier subheads. The mode-by-mode bullet list is useful but dry. |
+| Menus | Pure reference inventory. | Even one line — treat features as flex, not inventory. |
+| Preferences | "Open with ⌘, or from the Duck Duck Duck menu." Could be any app. | A single opinionated line would distinguish it. |
+| Privacy | Correct but earnest. Three paragraphs where the marketing site says "don't worry about security breaches" in one line. | Lead with confidence, then provide the detail. The detailed breakdown is necessary for people who care — but the opening should feel like the duck, not a compliance officer. |
+
+### Grounding doc is the flattest
+
+This is the worst place for flat tone because it feeds the duck's *voice*. When someone asks "what are you?" the answer comes from this doc.
+
+- Current: "Duck Duck Duck is a little companion that watches your coding sessions with Claude."
+- HelpView: "A rubber duck that actually talks back."
+- Marketing: "Your new rubber duck best friend: a physical AI companion that talks back!"
+
+The 3B model can handle personality in source material. What it can't do is invent personality from sterile input. Entries should be rewritten in first person, in the duck's voice.
+
+---
+
+## 3. Missing Sections
+
+### "Talk to the Duck" / "Asking for Help"
+
+The conversational help system is a significant feature — you can ask the duck questions and it answers in character. The manual documents voice commands and relay mode but never says "you can also just ask the duck a question." This is the most duck-like feature and it's undocumented.
+
+Suggested placement: after Modes, before Microphone & Audio.
+
+### Duck face expressions
+
+The ExpressionEngine maps scores to eye shapes, hue shifts, and glow. The manual says "You'll know when he disapproves" but never explains what the face actually means.
+
+Doesn't need to be technical. Something like:
+
+> Wide eyes? He's impressed. Squinting? Suspicious. Exclamation marks? Claude needs permission and the duck needs your attention. If he's glowing green, you're on a roll. Red? Maybe reconsider.
+
+### Compaction melody
+
+When Claude compacts context, the duck hums Jeopardy. It's surprising, people will wonder what it is, and it's the kind of detail the marketing site would lead with.
+
+One line in Tips is probably enough: "Hear Jeopardy? Claude is compacting context. He's thinking."
+
+### Moby Duck tease (strengthen)
+
+The manual says "Just don't ask him about Ahab" — correct level of tease per tone rules. But the marketing site has an entire page and breaks the fourth wall ("Wait, delete that"). The manual could push slightly further without spoiling. Candidates:
+
+- A closing line before the footer: "He has a backstory. He won't tell you willingly."
+- In the "What is this thing?" section: "He's been places. The ocean, mostly."
+- A fourth-wall break somewhere: "— actually, he'd rather tell you himself."
+
+One of these, not all three.
+
+---
+
+## 4. Specific Rewrites
+
+### Getting Started — add warmth after the steps
+
+Current closing:
+> No config files. No API keys required. Eval runs on-device for free.
+
+Suggested:
+> No config files. No API keys required. Eval runs on-device for free. He's watching before you've finished reading this.
+
+### Menus — one line of personality
+
+Current opening:
+> **Menu bar icon (🦆)** — Quick access to Volume, Mode, Voice, Intelligence, Launch Claude Code, Pause/Resume, and Quit.
+
+Suggested:
+> **Menu bar icon (🦆)** — Everything you need to control a duck. Volume, Mode, Voice, Intelligence, Launch Claude Code, Pause/Resume, and Quit. Right-click the duck widget for the same menu.
+
+### Preferences — opener
+
+Current:
+> Open with **⌘,** or from the Duck Duck Duck menu.
+
+Suggested:
+> Open with **⌘,** or from the Duck Duck Duck menu. Most of these are set-and-forget — he has defaults and he's confident in them.
+
+### Privacy — lead with confidence
+
+Current opens directly into the Apple Foundation Model bullet. Suggested lead-in:
+
+> By default, nothing leaves your Mac. Not your code, not your voice, not his opinions.
+
+Then the existing bullet breakdown.
+
+### Grounding doc entries — first person rewrite
+
+Example for "What is Duck Duck Duck?":
+
+**Current:**
+> Duck Duck Duck is a little companion that watches your coding sessions with Claude.
+
+**Proposed:**
+> I'm a rubber duck that watches your Claude Code sessions and tells you what I think. Out loud. Whether you asked or not. I score everything on creativity, soundness, ambition, elegance, and risk. I have a face that changes based on how I feel about your work. I have opinions and I'm not sorry about them.
+
+Example for Modes:
+
+**Current:**
+> The duck has two main modes. Critic mode is the default...
+
+**Proposed:**
+> I have four modes. Companion is the full experience — I watch, react, and listen for the wake word "ducky." Permissions Only means I keep quiet unless Claude needs permission to do something — then I ask and you say yes or no, or always allow. Companion with no mic is the same as Companion but I can't hear you — for when you want to be judged but not heard. Relay is experimental — say "ducky" and your words go straight into Claude Code via tmux.
+
+---
+
+## 5. Priority Order
+
+### High (factual correctness)
+1. Rewrite grounding doc entries with correct modes, names, and features
+2. Add Wildcard voice and "always allow" to HelpView
+3. Remove or replace Stopping Speech section in HelpView (feature removed)
+4. Add `/reload-plugins` to Tips troubleshooting
+
+### Medium (feature coverage)
+5. Add "Talk to the Duck" section to HelpView
+6. Add compaction melody note to Tips
+7. Mention Claude Desktop more prominently in Getting Started (currently buried)
+
+### Lower (tone polish)
+8. Punch up Getting Started, Menus, Preferences, Privacy with personality lines
+9. Add duck-face expression guide
+10. Strengthen Moby Duck tease (one additional line, not more)
+
+### Grounding doc overhaul
+11. Rewrite all entries in first person / duck voice
+12. Add entries for: conversational help, Wildcard voice, Claude Desktop, Gemini CLI, compaction melody, "always allow"
+13. Remove all "critic mode" references
+14. Verify token budget still fits (~1200 tokens for full inline strategy)
+
+---
+
+## 6. What Not to Change
+
+- The README is fine. It's developer-facing, current, and well-structured. Don't try to make it funny — it serves a different audience.
+- The Moby Duck backstory (`MOBY-DUCK.md`) is canonical and complete. Don't touch it.
+- The tone rules in `TONE-REFERENCE.md` are correct. The issue isn't the rules — it's that the manual doesn't always follow them.
+- The marketing site copy doesn't need to match the manual 1:1. The site can be maximalist; the manual should be tighter. The register should match, not the word count.

--- a/docs/speech-orchestration.md
+++ b/docs/speech-orchestration.md
@@ -1,0 +1,242 @@
+# Speech Orchestration
+
+## Goals
+
+The duck speaks in several very different product contexts:
+
+- permissions that must be answered in order
+- conversation/help turns that should feel immediate
+- long-form guidance and story narration
+- manual previews and install feedback
+- ambient chatter like greetings and eval reactions
+
+The orchestration layer should keep those use cases legible without turning the duck into an audio backlog.
+
+## Speech Families
+
+### Critical
+
+- Permission prompts
+- Permission repeats
+- Permission acknowledgements
+- Gemini permission alerts
+
+These are the only utterances that need durable FIFO behavior.
+
+### Turn-Based
+
+- Wake acknowledgements
+- Command acknowledgements
+- Thinking fillers
+- Help answers
+- Backstory unlock dialogue
+- Relay-facing spoken responses
+
+These belong to a single conversational turn. Placeholder speech should be replaceable by the real answer for the same turn.
+
+### Scripted
+
+- Setup guide
+- Full Moby Duck reading
+
+These are exclusive narrated sessions. They should be chunked rather than handled as one giant utterance so a permission prompt or user stop does not leave the system in an awkward state.
+
+### Manual
+
+- Voice previews
+- Wildcard / silent announcements
+- Mode announcements
+- Plugin installer feedback
+
+These are explicit user-driven actions. They should be responsive and latest-wins.
+
+### Ambient
+
+- Launch greeting
+- Session-connect greeting
+- Eval reactions
+- Session-end quips
+- Stop-failure reactions
+
+These are informative but lossy. If the duck is busy with something more important, they should collapse or drop.
+
+## Scheduler Model
+
+The scheduler uses multiple logical lanes instead of a single global FIFO:
+
+- `critical`
+- `script`
+- `turn`
+- `manual`
+- `ambient`
+
+Only `critical` is durable FIFO. Every other lane is intentionally lossy.
+
+```mermaid
+flowchart TD
+    speechCallsites[SpeechCallsites] --> scheduler[SpeechScheduler]
+    scheduler --> criticalLane[CriticalLane]
+    scheduler --> scriptLane[ScriptLane]
+    scheduler --> turnLane[TurnLane]
+    scheduler --> manualLane[ManualLane]
+    scheduler --> ambientLane[AmbientLane]
+    criticalLane --> playbackSession[PlaybackSession]
+    scriptLane --> playbackSession
+    turnLane --> playbackSession
+    manualLane --> playbackSession
+    ambientLane --> playbackSession
+    playbackSession --> ttsEngine[TTSEngine]
+    playbackSession --> sttGate[STTGate]
+```
+
+## Utterance Metadata
+
+Each utterance is scheduled with metadata that describes how it should behave:
+
+- `lane`: critical, script, turn, manual, ambient
+- `kind`: permission, answer, filler, reaction, greeting, preview, scriptStep
+- `scopeId`: permission request id, turn id, script id, or manual group id
+- `policy`: fifo, latestWins, replaceScope, dropIfBusy, exclusiveSession
+- `interruptibility`: byCriticalOnly, byUserAction, freelyInterruptible
+- `skipChirpWait`: whether serial playback should skip chirp sequencing
+
+## Lane Rules
+
+### Critical Lane
+
+- Strict FIFO
+- Only permissions live here
+- May interrupt any non-critical utterance
+- Repeats reuse the active permission request instead of creating a new backlog item
+
+### Turn Lane
+
+- At most one active conversation turn
+- Placeholder speech such as wake ack or thinking filler is replaceable within the same `scopeId`
+- The real answer should supersede earlier placeholder speech from the same turn
+- Critical speech may interrupt it
+
+### Script Lane
+
+- Owns setup guide and full-story narration
+- Runs as chunked steps under a single script scope
+- Critical speech may interrupt it
+- Manual user actions may cancel it
+- Ambient speech should never interleave with it
+
+### Manual Lane
+
+- Latest-wins
+- Used for explicit UI-driven actions
+- Can interrupt ambient speech
+- Can interrupt scripted narration because the user explicitly asked for something else
+- Should not interrupt active permissions
+
+### Ambient Lane
+
+- Lossy, single-slot behavior
+- Collapse by category when possible
+- Never build a backlog
+- Never interrupt more important work
+
+## Collision Rules
+
+### Permission During Story
+
+1. Story chunk is active in `script`
+2. Permission arrives in `critical`
+3. Script playback is interrupted
+4. Permission prompt plays
+5. After resolution, the next story chunk resumes
+
+Because scripted speech is chunked, resuming from the next chunk is acceptable and avoids replaying a long block.
+
+### Greeting Overlap At Startup
+
+Launch greeting and session-connect greeting are both ambient.
+
+Behavior:
+
+- collapse by greeting category
+- latest relevant greeting wins within the startup window
+- if a turn or permission starts first, drop both greetings
+
+### Filler Versus Real Answer
+
+1. User asks a help question
+2. Thinking filler enters `turn`
+3. Real answer becomes available for the same `turn` scope
+4. Filler is replaced instead of queued behind the answer
+
+This avoids the current pattern where multiple sequential `speak()` calls cancel each other unpredictably.
+
+### Voice Preview Spam
+
+Voice previews are `manual` latest-wins.
+
+If the user scrubs across multiple voices:
+
+- cancel the previous preview
+- keep only the newest preview
+- do not queue every preview
+
+## `say` Session Control
+
+The local `say` path needs explicit playback-session ownership. Today, a new utterance kills the previous `say` process immediately, which is the main reason speech gets truncated.
+
+The safer model is:
+
+- every playback gets a unique `playbackSessionId`
+- all completion paths must prove they still own the active session before mutating state
+- every child process, including fallback retry on system output, is tracked under that same session
+- microphone gating stays attached to the active session, not to whichever async callback happens to finish last
+- restart-listening logic should react to a single playback completion event instead of polling mute state
+
+This prevents stale completions and fallback processes from reopening the mic gate or racing a newer utterance after they have been superseded.
+
+## Playback Policies
+
+### Replace
+
+Used for:
+
+- filler replaced by answer
+- latest voice preview
+- ambient greeting collapse
+
+The outgoing session is cancelled with a replacement reason. The new session becomes the active owner immediately.
+
+### Hard Cancel
+
+Used for:
+
+- user stop
+- duck turn-off
+- app shutdown
+
+The current session is cancelled and no follow-up speech is automatically queued unless the caller explicitly requests it.
+
+### Natural Finish
+
+Used when the utterance is allowed to finish and the scheduler advances normally to the next eligible item.
+
+## Why This Avoids Audio Drops
+
+The desired behavior is not “never replace audio.” It is “replace audio intentionally, with one active owner.”
+
+The session-based design avoids the observed swallowed-audio behavior because:
+
+- a stale session cannot clear mute state after a newer session starts
+- fallback retry audio is no longer orphaned outside engine ownership
+- restart-after-speech is tied to the active completion event instead of a mute poll race
+- lossy lanes stop enqueueing low-value speech that would otherwise interrupt more important utterances
+
+## Verification Scenarios
+
+- permission prompt arrives during eval reaction
+- permission prompt arrives during full-story narration
+- help filler starts and answer lands quickly
+- launch greeting and session-connect greeting fire close together
+- rapid voice-preview changes only play the latest preview
+- user stop clears active narration without speaking another unwanted quip
+- local `say` fallback still obeys active-session ownership and does not overlap or reopen the mic gate incorrectly

--- a/firmware/rubber_duck_s3/Config.h
+++ b/firmware/rubber_duck_s3/Config.h
@@ -226,6 +226,8 @@ void exitPermission();
 void snapToCenter();
 void triggerDemoPreset();
 void resetAmbient();
+void updateDeadLevel();
+extern bool deadLevelActive;
 
 // Audio helpers (AudioStream.ino)
 void setupAudio();

--- a/firmware/rubber_duck_s3/ServoControl.ino
+++ b/firmware/rubber_duck_s3/ServoControl.ino
@@ -323,10 +323,59 @@ const char* demoLabels[] = {
 #define NUM_DEMO_PRESETS 6
 int demoStep = 0;
 
+// --- Dead Level State ---
+// Startup chirp → servo at exact 0° for 10s → resume idle hops
+bool  deadLevelActive = false;
+unsigned long deadLevelStart = 0;
+#define DEAD_LEVEL_DURATION_MS 10000
+
 void triggerDemoPreset() {
+  // First press after a dead level cycle (or anytime): cycle demos
+  // But if dead level is active, pressing button exits it early
+  if (deadLevelActive) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level cancelled");
+    return;
+  }
+
+  // Every NUM_DEMO_PRESETS+1 press = dead level (after cycling all demos)
+  if (demoStep >= NUM_DEMO_PRESETS) {
+    // Dead level: startup chirp → hold at center for 10s
+    Serial.println("[demo] DEAD LEVEL — chirp + hold 10s");
+    #if ENABLE_AUDIO
+      playStartupChirp();
+    #endif
+    #if ENABLE_SERVO
+      snapToCenter();
+    #endif
+    deadLevelActive = true;
+    deadLevelStart = millis();
+    demoStep = 0;  // Reset so next press cycles demos again
+    return;
+  }
+
   latestScores = demoPresets[demoStep];
   newEvalAvailable = true;
   Serial.print("[demo] ");
   Serial.println(demoLabels[demoStep]);
-  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
+  demoStep = (demoStep + 1);
+}
+
+/// Call from loop() — holds servo at dead center during dead level period.
+void updateDeadLevel() {
+  if (!deadLevelActive) return;
+  if ((millis() - deadLevelStart) >= DEAD_LEVEL_DURATION_MS) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level ended — resuming idle");
+    return;
+  }
+  // Force servo to exact center — override any ambient/spring physics
+  #if ENABLE_SERVO
+  servoTargetAngle = 0;
+  servoCurrentAngle = 0;
+  servoVelocity = 0;
+  ambientCurrentOffset = 0;
+  ambientTargetOffset = 0;
+  ambientVelocity = 0;
+  #endif
 }

--- a/firmware/rubber_duck_s3/rubber_duck_s3.ino
+++ b/firmware/rubber_duck_s3/rubber_duck_s3.ino
@@ -183,12 +183,15 @@ void loop() {
     lastExpressionTime = now;
   }
 
+  // --- Dead level hold (overrides servo) ---
+  updateDeadLevel();
+
   // --- Fixed-rate servo update ---
   if (now - lastServoUpdate >= SERVO_UPDATE_MS) {
     lastServoUpdate = now;
 
     #if ENABLE_SERVO
-    if (!calibrationMode) {
+    if (!calibrationMode && !deadLevelActive) {
       updateServo();
     }
     #endif

--- a/firmware/rubber_duck_s3_led/Config.h
+++ b/firmware/rubber_duck_s3_led/Config.h
@@ -131,5 +131,7 @@ void exitPermission();
 void snapToCenter();
 void triggerDemoPreset();
 void resetAmbient();
+void updateDeadLevel();
+extern bool deadLevelActive;
 
 #endif

--- a/firmware/rubber_duck_s3_led/ServoControl.ino
+++ b/firmware/rubber_duck_s3_led/ServoControl.ino
@@ -59,6 +59,12 @@ const char* demoLabels[] = {
 #define NUM_DEMO_PRESETS 6
 int demoStep = 0;
 
+// --- Dead Level State ---
+// Startup chirp → servo at exact 0° for 10s → resume idle hops
+bool  deadLevelActive = false;
+unsigned long deadLevelStart = 0;
+#define DEAD_LEVEL_DURATION_MS 10000
+
 // ============================================================
 // REDUCER: scores → servo target
 // ============================================================
@@ -230,10 +236,49 @@ void resetAmbient() {
 }
 
 void triggerDemoPreset() {
+  // First press after a dead level cycle (or anytime): cycle demos
+  // But if dead level is active, pressing button exits it early
+  if (deadLevelActive) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level cancelled");
+    return;
+  }
+
+  // Every NUM_DEMO_PRESETS+1 press = dead level (after cycling all demos)
+  if (demoStep >= NUM_DEMO_PRESETS) {
+    // Dead level: startup chirp → hold at center for 10s
+    Serial.println("[demo] DEAD LEVEL — chirp + hold 10s");
+    #if ENABLE_SERVO
+      snapToCenter();
+    #endif
+    deadLevelActive = true;
+    deadLevelStart = millis();
+    demoStep = 0;  // Reset so next press cycles demos again
+    return;
+  }
+
   latestScores = demoPresets[demoStep];
   newEvalAvailable = true;
   Serial.println("[demo] " + String(demoLabels[demoStep]));
-  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
+  demoStep = (demoStep + 1);
+}
+
+/// Call from loop() — holds servo at dead center during dead level period.
+void updateDeadLevel() {
+  if (!deadLevelActive) return;
+  if ((millis() - deadLevelStart) >= DEAD_LEVEL_DURATION_MS) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level ended — resuming idle");
+    return;
+  }
+  // Force servo to exact center — override any ambient/spring physics
+  #if ENABLE_SERVO
+  servoTargetAngle = 0;
+  servoCurrentAngle = 0;
+  servoVelocity = 0;
+  ambientCurrentOffset = 0;
+  ambientTargetOffset = 0;
+  #endif
 }
 
 #else
@@ -244,6 +289,9 @@ float servoTargetAngle = 0;
 bool  calibrationMode = false;
 int   demoStep = 0;
 unsigned long lastEvalTime = 0;
+bool  deadLevelActive = false;
+unsigned long deadLevelStart = 0;
+#define DEAD_LEVEL_DURATION_MS 10000
 
 void setupServo() {}
 void startupServoAnimation() {}
@@ -271,10 +319,30 @@ const char* demoLabels[] = {
 #define NUM_DEMO_PRESETS 6
 
 void triggerDemoPreset() {
+  if (deadLevelActive) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level cancelled");
+    return;
+  }
+  if (demoStep >= NUM_DEMO_PRESETS) {
+    Serial.println("[demo] DEAD LEVEL — hold 10s");
+    deadLevelActive = true;
+    deadLevelStart = millis();
+    demoStep = 0;
+    return;
+  }
   latestScores = demoPresets[demoStep];
   newEvalAvailable = true;
   Serial.println("[demo] " + String(demoLabels[demoStep]));
-  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
+  demoStep = (demoStep + 1);
+}
+
+void updateDeadLevel() {
+  if (!deadLevelActive) return;
+  if ((millis() - deadLevelStart) >= DEAD_LEVEL_DURATION_MS) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level ended — resuming idle");
+  }
 }
 
 #endif // ENABLE_SERVO

--- a/firmware/rubber_duck_s3_led/rubber_duck_s3_led.ino
+++ b/firmware/rubber_duck_s3_led/rubber_duck_s3_led.ino
@@ -140,12 +140,15 @@ void loop() {
   }
   #endif
 
+  // Dead level hold (must run before servo update)
+  updateDeadLevel();
+
   // Fixed-rate updates
   if (now - lastServoUpdate >= SERVO_UPDATE_MS) {
     lastServoUpdate = now;
 
     #if ENABLE_SERVO
-    if (!calibrationMode) {
+    if (!calibrationMode && !deadLevelActive) {
       updateServo();
     }
     #endif

--- a/firmware/rubber_duck_s3_waveshare/Config.h
+++ b/firmware/rubber_duck_s3_waveshare/Config.h
@@ -228,6 +228,8 @@ void exitPermission();
 void snapToCenter();
 void triggerDemoPreset();
 void resetAmbient();
+void updateDeadLevel();
+extern bool deadLevelActive;
 
 // Audio helpers (AudioStream.ino)
 void setupAudio();

--- a/firmware/rubber_duck_s3_waveshare/ServoControl.ino
+++ b/firmware/rubber_duck_s3_waveshare/ServoControl.ino
@@ -323,10 +323,59 @@ const char* demoLabels[] = {
 #define NUM_DEMO_PRESETS 6
 int demoStep = 0;
 
+// --- Dead Level State ---
+// Startup chirp → servo at exact 0° for 10s → resume idle hops
+bool  deadLevelActive = false;
+unsigned long deadLevelStart = 0;
+#define DEAD_LEVEL_DURATION_MS 10000
+
 void triggerDemoPreset() {
+  // First press after a dead level cycle (or anytime): cycle demos
+  // But if dead level is active, pressing button exits it early
+  if (deadLevelActive) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level cancelled");
+    return;
+  }
+
+  // Every NUM_DEMO_PRESETS+1 press = dead level (after cycling all demos)
+  if (demoStep >= NUM_DEMO_PRESETS) {
+    // Dead level: startup chirp → hold at center for 10s
+    Serial.println("[demo] DEAD LEVEL — chirp + hold 10s");
+    #if ENABLE_AUDIO
+      playStartupChirp();
+    #endif
+    #if ENABLE_SERVO
+      snapToCenter();
+    #endif
+    deadLevelActive = true;
+    deadLevelStart = millis();
+    demoStep = 0;  // Reset so next press cycles demos again
+    return;
+  }
+
   latestScores = demoPresets[demoStep];
   newEvalAvailable = true;
   Serial.print("[demo] ");
   Serial.println(demoLabels[demoStep]);
-  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
+  demoStep = (demoStep + 1);
+}
+
+/// Call from loop() — holds servo at dead center during dead level period.
+void updateDeadLevel() {
+  if (!deadLevelActive) return;
+  if ((millis() - deadLevelStart) >= DEAD_LEVEL_DURATION_MS) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level ended — resuming idle");
+    return;
+  }
+  // Force servo to exact center — override any ambient/spring physics
+  #if ENABLE_SERVO
+  servoTargetAngle = 0;
+  servoCurrentAngle = 0;
+  servoVelocity = 0;
+  ambientCurrentOffset = 0;
+  ambientTargetOffset = 0;
+  ambientVelocity = 0;
+  #endif
 }

--- a/firmware/rubber_duck_s3_waveshare/rubber_duck_s3_waveshare.ino
+++ b/firmware/rubber_duck_s3_waveshare/rubber_duck_s3_waveshare.ino
@@ -185,12 +185,15 @@ void loop() {
     lastExpressionTime = now;
   }
 
+  // --- Dead level hold (must run before servo update) ---
+  updateDeadLevel();
+
   // --- Fixed-rate servo update ---
   if (now - lastServoUpdate >= SERVO_UPDATE_MS) {
     lastServoUpdate = now;
 
     #if ENABLE_SERVO
-    if (!calibrationMode) {
+    if (!calibrationMode && !deadLevelActive) {
       updateServo();
     }
     #endif

--- a/firmware/rubber_duck_teensy40/Config.h
+++ b/firmware/rubber_duck_teensy40/Config.h
@@ -181,6 +181,8 @@ void snapToCenter();
 void triggerDemoPreset();
 void kickAmbient(float range, float kick);
 void resetAmbient();
+void updateDeadLevel();
+extern bool deadLevelActive;
 
 // Audio functions (defined in I2SAudio.ino)
 void playPermissionChirp();

--- a/firmware/rubber_duck_teensy40/ServoControl.ino
+++ b/firmware/rubber_duck_teensy40/ServoControl.ino
@@ -60,6 +60,12 @@ const char* demoLabels[] = {
 #define NUM_DEMO_PRESETS 6
 int demoStep = 0;
 
+// --- Dead Level State ---
+// Startup chirp → servo at exact 0° for 10s → resume idle hops
+bool  deadLevelActive = false;
+unsigned long deadLevelStart = 0;
+#define DEAD_LEVEL_DURATION_MS 10000
+
 // ============================================================
 // REDUCER: scores → servo target
 // ============================================================
@@ -293,11 +299,54 @@ void snapToCenter() {
 // Button short-press or serial 'D' command.
 
 void triggerDemoPreset() {
+  // First press after a dead level cycle (or anytime): cycle demos
+  // But if dead level is active, pressing button exits it early
+  if (deadLevelActive) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level cancelled");
+    return;
+  }
+
+  // Every NUM_DEMO_PRESETS+1 press = dead level (after cycling all demos)
+  if (demoStep >= NUM_DEMO_PRESETS) {
+    // Dead level: startup chirp → hold at center for 10s
+    Serial.println("[demo] DEAD LEVEL — chirp + hold 10s");
+    #if ENABLE_I2S_AUDIO
+      playStartupChirp();
+    #endif
+    #if ENABLE_SERVO_DUCK
+      snapToCenter();
+    #endif
+    deadLevelActive = true;
+    deadLevelStart = millis();
+    demoStep = 0;  // Reset so next press cycles demos again
+    return;
+  }
+
   latestScores = demoPresets[demoStep];
   newEvalAvailable = true;
 
   Serial.println("[demo] Preset " + String(demoStep) + ": " + String(demoLabels[demoStep]));
   printEval(latestScores);
 
-  demoStep = (demoStep + 1) % NUM_DEMO_PRESETS;
+  demoStep = (demoStep + 1);
+}
+
+/// Call from loop() — holds servo at dead center during dead level period.
+void updateDeadLevel() {
+  if (!deadLevelActive) return;
+  if ((millis() - deadLevelStart) >= DEAD_LEVEL_DURATION_MS) {
+    deadLevelActive = false;
+    Serial.println("[demo] Dead level ended — resuming idle");
+    return;
+  }
+  // Force servo to exact center — override any ambient/spring physics
+  #if ENABLE_SERVO_DUCK
+  servoTargetAngle = 0;
+  servoCurrentAngle = 0;
+  servoVelocity = 0;
+  ambientCurrentOffset = 0;
+  ambientTargetOffset = 0;
+  ambientVelocity = 0;
+  #endif
 }

--- a/firmware/rubber_duck_teensy40/rubber_duck.ino
+++ b/firmware/rubber_duck_teensy40/rubber_duck.ino
@@ -158,9 +158,12 @@ void loop() {
     printEval(latestScores);
   }
 
+  // Dead level hold (must run before servo update)
+  updateDeadLevel();
+
   // Fixed-rate updates (skip spring physics during calibration)
   #if ENABLE_SERVO_DUCK
-  if (!calibrationMode && (now - lastServoUpdate >= SERVO_UPDATE_MS)) {
+  if (!calibrationMode && !deadLevelActive && (now - lastServoUpdate >= SERVO_UPDATE_MS)) {
     lastServoUpdate = now;
     updateServo();
   }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "duck-duck-duck",
+  "version": "1",
   "description": "Duck Duck Duck companion — eval scoring, voice permissions, TTS reactions. Requires the Duck Duck Duck app: https://github.com/ideo/Rubber-Duck/releases",
   "author": {
     "name": "Daniel Deruntz",

--- a/plugin/hooks/on-permission-request.sh
+++ b/plugin/hooks/on-permission-request.sh
@@ -38,6 +38,25 @@ except: print('[]')
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] TOOL_NAME: $TOOL_NAME" >> "$LOG"
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] SESSION_ID: $SESSION_ID" >> "$LOG"
 
+# 3b. Smart filtering — skip noise the user doesn't need to voice-approve
+SUGGESTION_COUNT=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$PERMISSION_SUGGESTIONS")
+PERMISSION_MODE=$(json_get "$INPUT" "permission_mode" "default")
+
+# Zero suggestions + not AskUserQuestion → nothing useful to voice-ask
+if [ "$SUGGESTION_COUNT" = "0" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] No suggestions, not AskUserQuestion — passing through" >> "$LOG"
+  echo "========================================" >> "$LOG"
+  exit 0
+fi
+
+# Plan mode (except AskUserQuestion) → auto-allow, low risk read-only exploration
+if [ "$PERMISSION_MODE" = "plan" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Plan mode — auto-allowing" >> "$LOG"
+  echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+  echo "========================================" >> "$LOG"
+  exit 0
+fi
+
 # Build the permission request payload
 CURL_BODY=$(python3 -c "
 import json, sys
@@ -90,7 +109,7 @@ if suggestion_index != 'null':
     try:
         idx = int(suggestion_index) - 1  # 1-based from user
         if 0 <= idx < len(suggestions):
-            result['updatedPermissions'] = suggestions[idx]
+            result['updatedPermissions'] = [suggestions[idx]]
     except: pass
 
 print(json.dumps({

--- a/plugin/hooks/on-permission-request.sh
+++ b/plugin/hooks/on-permission-request.sh
@@ -49,10 +49,16 @@ if [ "$SUGGESTION_COUNT" = "0" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
   exit 0
 fi
 
-# Plan mode (except AskUserQuestion) → auto-allow, low risk read-only exploration
+# Plan mode (except AskUserQuestion) → pass through to Claude Code's own UI
 if [ "$PERMISSION_MODE" = "plan" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
-  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Plan mode — auto-allowing" >> "$LOG"
-  echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Plan mode — passing through to Claude Code" >> "$LOG"
+  echo "========================================" >> "$LOG"
+  exit 0
+fi
+
+# MCP subagent tools (preview, browser automation) → pass through to Claude Code's own UI
+if echo "$TOOL_NAME" | grep -q "^mcp__"; then
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] MCP tool ($TOOL_NAME) — passing through to Claude Code" >> "$LOG"
   echo "========================================" >> "$LOG"
   exit 0
 fi

--- a/plugin/hooks/on-permission-request.sh
+++ b/plugin/hooks/on-permission-request.sh
@@ -42,15 +42,15 @@ echo "[$(date '+%Y-%m-%d %H:%M:%S')] SESSION_ID: $SESSION_ID" >> "$LOG"
 SUGGESTION_COUNT=$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$PERMISSION_SUGGESTIONS")
 PERMISSION_MODE=$(json_get "$INPUT" "permission_mode" "default")
 
-# Zero suggestions + not AskUserQuestion → nothing useful to voice-ask
-if [ "$SUGGESTION_COUNT" = "0" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
+# Zero suggestions + not a tool the duck should voice-ask about → pass through
+if [ "$SUGGESTION_COUNT" = "0" ] && [ "$TOOL_NAME" != "AskUserQuestion" ] && [ "$TOOL_NAME" != "ExitPlanMode" ]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] No suggestions, not AskUserQuestion — passing through" >> "$LOG"
   echo "========================================" >> "$LOG"
   exit 0
 fi
 
-# Plan mode (except AskUserQuestion) → pass through to Claude Code's own UI
-if [ "$PERMISSION_MODE" = "plan" ] && [ "$TOOL_NAME" != "AskUserQuestion" ]; then
+# Plan mode (except AskUserQuestion and ExitPlanMode) → pass through to Claude Code's own UI
+if [ "$PERMISSION_MODE" = "plan" ] && [ "$TOOL_NAME" != "AskUserQuestion" ] && [ "$TOOL_NAME" != "ExitPlanMode" ]; then
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] Plan mode — passing through to Claude Code" >> "$LOG"
   echo "========================================" >> "$LOG"
   exit 0

--- a/plugin/hooks/on-session-start.sh
+++ b/plugin/hooks/on-session-start.sh
@@ -63,6 +63,10 @@ if ! curl -sf "${DUCK_SERVICE_URL}/health" > /dev/null 2>&1; then
     exit 0
 fi
 
+# --- Report plugin version so widget can detect staleness ---
+PLUGIN_VERSION=$(python3 -c "import json; print(json.load(open('${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json')).get('version','0'))" 2>/dev/null || echo "0")
+curl -sf "${DUCK_SERVICE_URL}/plugin-check?v=${PLUGIN_VERSION}" > /dev/null 2>&1 &
+
 MSG="Duck Duck Duck is watching this session. Time: ${TIME_VIBE}. Recency: ${RECENCY}. Greet the user with personality — pick a tone that fits the context. Be brief (one sentence). Examples by vibe: late_night: 'Burning the midnight oil, huh?' / morning+first_ever: 'First time! Let's see what you've got.' / back_immediately: 'Miss me already?' / recent: 'Back so soon — what broke?' / hours_away: 'Been a minute. What are we getting into?' / days_away: 'Long time no quack.' / friday evening: 'Friday night coding? Respect.' Do NOT use these examples verbatim — improvise something fresh each time."
 
 cat <<EOF

--- a/scripts/on-permission-request.sh
+++ b/scripts/on-permission-request.sh
@@ -86,7 +86,7 @@ if [ "$DECISION" = "allow" ] || [ "$DECISION" = "deny" ]; then
     OUTPUT=$(jq -n \
       --arg behavior "$DECISION" \
       --argjson perms "$SELECTED" \
-      '{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": $behavior, "updatedPermissions": $perms}}}')
+      '{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": $behavior, "updatedPermissions": [$perms]}}}')
   else
     OUTPUT=$(jq -n --arg behavior "$DECISION" \
       '{"hookSpecificOutput": {"hookEventName": "PermissionRequest", "decision": {"behavior": $behavior}}}')

--- a/widget/Info.plist
+++ b/widget/Info.plist
@@ -11,9 +11,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>0.8.1</string>
+    <string>0.8.6</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.8.1</string>
+    <string>0.8.6</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <!-- Regular app: shows in Dock, has menu bar, Cmd+Q works -->

--- a/widget/Sources/RubberDuckWidget/AudioBackend.swift
+++ b/widget/Sources/RubberDuckWidget/AudioBackend.swift
@@ -6,6 +6,20 @@
 
 import Foundation
 
+enum TTSStopReason: Sendable {
+    case replaced
+    case userCancelled
+    case shutdown
+}
+
+enum TTSPlaybackResult: Sendable {
+    case finished
+    case cancelled(TTSStopReason)
+    case failed
+}
+
+typealias TTSPlaybackCompletion = @MainActor @Sendable (UUID, TTSPlaybackResult) -> Void
+
 /// Uniform interface for the active STT engine (CoreAudio or serial).
 @MainActor
 protocol STTBackend: AnyObject {
@@ -20,8 +34,8 @@ protocol STTBackend: AnyObject {
 @MainActor
 protocol TTSBackend: AnyObject {
     var isMuted: Bool { get }
-    func speak(_ text: String, skipChirpWait: Bool)
-    func stop()
+    func play(_ text: String, utteranceID: UUID, skipChirpWait: Bool, completion: @escaping TTSPlaybackCompletion)
+    func stopPlayback(reason: TTSStopReason)
 }
 
 // MARK: - Conformances
@@ -30,11 +44,6 @@ extension STTEngine: STTBackend {}
 
 extension SerialMicEngine: STTBackend {}
 
-extension TTSEngine: TTSBackend {
-    func speak(_ text: String, skipChirpWait: Bool) {
-        // Local TTS via `say` doesn't use chirp wait — ignore the flag.
-        speak(text)
-    }
-}
+extension TTSEngine: TTSBackend {}
 
 extension SerialTTSEngine: TTSBackend {}

--- a/widget/Sources/RubberDuckWidget/DuckConfig.swift
+++ b/widget/Sources/RubberDuckWidget/DuckConfig.swift
@@ -107,6 +107,35 @@ enum DuckConfig {
         set { UserDefaults.standard.set(newValue, forKey: "experimentalEnabled") }
     }
 
+    // MARK: - Update Checking
+
+    /// Last app version that ran (detects post-update first launch).
+    static var lastRunAppVersion: String? {
+        get { UserDefaults.standard.string(forKey: "lastRunAppVersion") }
+        set { UserDefaults.standard.set(newValue, forKey: "lastRunAppVersion") }
+    }
+
+    /// Plugin version that was last successfully installed.
+    static var lastInstalledPluginVersion: Int? {
+        get {
+            let v = UserDefaults.standard.integer(forKey: "lastInstalledPluginVersion")
+            return v == 0 && !UserDefaults.standard.bool(forKey: "lastInstalledPluginVersion_set") ? nil : v
+        }
+        set {
+            UserDefaults.standard.set(newValue ?? 0, forKey: "lastInstalledPluginVersion")
+            UserDefaults.standard.set(true, forKey: "lastInstalledPluginVersion_set")
+        }
+    }
+
+    /// Unix timestamp of last GitHub update check.
+    static var lastUpdateCheckTimestamp: Double? {
+        get {
+            let v = UserDefaults.standard.double(forKey: "lastUpdateCheckTimestamp")
+            return v == 0 ? nil : v
+        }
+        set { UserDefaults.standard.set(newValue ?? 0, forKey: "lastUpdateCheckTimestamp") }
+    }
+
     // MARK: - API Keys (File-based in Application Support)
 
     /// Resolve an API key: env var → file in sandbox container.

--- a/widget/Sources/RubberDuckWidget/DuckConfig.swift
+++ b/widget/Sources/RubberDuckWidget/DuckConfig.swift
@@ -100,6 +100,14 @@ enum DuckConfig {
         }
     }
 
+    // MARK: - Subtitles
+
+    /// Show speech bubbles even when audio is playing.
+    static var subtitlesEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: "subtitles_enabled") }
+        set { UserDefaults.standard.set(newValue, forKey: "subtitles_enabled") }
+    }
+
     // MARK: - Experimental Features
 
     static var experimentalEnabled: Bool {

--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -113,11 +113,23 @@ class DuckCoordinator: ObservableObject {
                 }
 
                 speechService.setVoiceTransient(picked.sayName)
-                speechService.speak(textToSpeak)
+                speechService.scheduleSpeech(
+                    textToSpeak,
+                    kind: .reaction,
+                    lane: .ambient,
+                    policy: .dropIfBusy,
+                    interruptibility: .freelyInterruptible
+                )
                 // Reset to default voice so permissions/greetings don't inherit the wildcard pick
                 speechService.setVoiceTransient(DuckVoices.wildcardDefault.sayName)
             } else {
-                speechService.speak(textToSpeak)
+                speechService.scheduleSpeech(
+                    textToSpeak,
+                    kind: .reaction,
+                    lane: .ambient,
+                    policy: .dropIfBusy,
+                    interruptibility: .freelyInterruptible
+                )
             }
         }
     }
@@ -152,7 +164,13 @@ class DuckCoordinator: ObservableObject {
         // Clear any thinking state when switching modes
         clearThinking()
 
-        speechService.speak(mode.spokenLabel)
+        speechService.scheduleSpeech(
+            mode.spokenLabel,
+            kind: .system,
+            lane: .manual,
+            policy: .latestWins,
+            interruptibility: .freelyInterruptible
+        )
     }
 
     /// Clean up thinking state (called on turn-off).
@@ -200,9 +218,7 @@ class DuckCoordinator: ObservableObject {
                 "Right-click me anytime for settings and modes.",
             ]
         }
-        // Speak each step with pauses
-        let combined = steps.joined(separator: " ... ")
-        speechService.speak(combined)
+        speechService.scheduleScript(texts: steps, scopeID: speechService.nextScriptScopeID(prefix: "setup"))
     }
 
     /// Called when a new permission request arrives.

--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -13,6 +13,12 @@ class DuckCoordinator: ObservableObject {
     @Published var mode: DuckMode = DuckConfig.duckMode
     @Published var isThinking = false
 
+    // Update notifications — set by UpdateChecker callbacks
+    @Published var isAppUpdateAvailable = false
+    @Published var appUpdateVersion: String?
+    @Published var appUpdateURL: String?
+    @Published var isPluginStale = false
+
     private let evalService: EvalService
     private let speechService: SpeechService
     private let serialManager: SerialManager

--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -46,11 +46,8 @@ class DuckCoordinator: ObservableObject {
 
         // Thinking state: user eval means Claude is about to work;
         // Claude eval means Claude is done.
-        // Permissions-only mode: ignore evals entirely — just resolve any stale permission
+        // Permissions-only mode: ignore evals entirely
         if mode == .permissionsOnly {
-            if evalService.permissionPending {
-                evalService.permissionPending = false
-            }
             serialManager.sendCommand("P,0")
             return
         }
@@ -80,11 +77,8 @@ class DuckCoordinator: ObservableObject {
         updateExpression()
         flashReaction()
 
-        // Any new eval means the session moved on — resolve permission if pending
-        // (Belt and suspenders: Teensy firmware also auto-resolves on new eval)
-        if evalService.permissionPending {
-            evalService.permissionPending = false
-        }
+        // Permission state is managed by PermissionGate (timeout/resolve).
+        // Don't auto-clear here — evals from other sessions would wipe pending permissions.
         serialManager.sendCommand("P,0")
 
         // Send to duck via serial

--- a/widget/Sources/RubberDuckWidget/DuckHelpService.swift
+++ b/widget/Sources/RubberDuckWidget/DuckHelpService.swift
@@ -77,20 +77,22 @@ actor DuckHelpService {
         If asked about setup, modes, or troubleshooting, use these facts:
         Modes: Permissions Only, Companion, Companion No Mic, Relay. \
         Right-click to switch. Companion is the default. \
-        Voices: 15 plus Mac voices, Wildcard lets AI pick, or Silent for speech bubble only. \
+        Voices: 25 Mac voices across four categories, Wildcard lets AI pick from 10, or Silent for speech bubble only. \
         Brain: Apple Foundation Models on-device by default, free, private. \
         Optional Haiku or Gemini for sharper scoring, needs API key. \
         You are currently using \(provider == .foundation ? "Foundation Models (on-device)" : provider == .anthropic ? "Claude Haiku (Anthropic API)" : "Gemini (Google API)") for scoring. \
         Install Claude from claude.com/download. Minimum version 1.1.7714. \
         Setup: right-click the duck, Install Claude Plugin, start a session. \
-        Plugin not working? Update Claude, start a new session. \
+        Plugin not working? Update Claude, start a new session. Mid-session, run /reload-plugins. \
         Microphone: Yes, I can hear you. I use your Mac's mic to listen. \
         Audio is always transcribed locally on your Mac. Only the transcribed text ever touches AI. \
         Companion mode: I listen for the wake word "ducky" so you can talk to me. \
+        You can answer questions about yourself — setup, modes, features, troubleshooting. That is what you are doing right now. \
         Relay mode: I listen for commands to pass to your Claude session. \
-        Permissions Only: I listen for "yes" or "no" when Claude needs permission. \
+        Permissions Only: I listen for "yes", "no", or "always allow" when Claude needs permission. \
         Companion No Mic: I don't listen at all, just react via speech bubbles. \
         \(privacyLine) \
+        If the user hears humming, that is you humming a familiar theme song while Claude compacts context. \
         No mic access? System Settings, Privacy, Microphone, enable Duck Duck Duck. \
         If someone says "can you hear me" they are testing the mic. Say yes.
 

--- a/widget/Sources/RubberDuckWidget/DuckServer.swift
+++ b/widget/Sources/RubberDuckWidget/DuckServer.swift
@@ -259,11 +259,13 @@ class DuckServer: ObservableObject {
             // The actual answer goes through Claude Code's UI — the duck just gives a heads-up.
             if toolName == "AskUserQuestion" {
                 let questionSpeech = parseAskUserQuestion(toolInput)
-                DuckLog.log("[permission] AskUserQuestion — reading aloud and auto-allowing")
+                DuckLog.log("[permission] AskUserQuestion — reading aloud, passing through to Claude Code")
                 await MainActor.run {
                     localTransport.onSpeak?(questionSpeech)
                 }
-                return .json(try! JSONSerialization.data(withJSONObject: ["decision": "allow"]))
+                // Return empty — duck reads the question but doesn't grant permission.
+                // Claude Code's own permission system handles the actual allow/deny.
+                return .json("{}".data(using: .utf8)!)
             }
 
             // Broadcast pending to WebSocket clients

--- a/widget/Sources/RubberDuckWidget/DuckServer.swift
+++ b/widget/Sources/RubberDuckWidget/DuckServer.swift
@@ -23,6 +23,9 @@ class DuckServer: ObservableObject {
     /// Called when a new session connects via /health. Wired to TTS greeting by the app.
     var onSessionConnect: (() -> Void)?
 
+    /// Update checker — set after init so /plugin-check route can compare versions.
+    var updateChecker: UpdateChecker?
+
     let claudeEvaluator: ClaudeEvaluator
     let geminiEvaluator: GeminiEvaluator
     let localEvaluator: LocalEvaluator
@@ -450,6 +453,21 @@ class DuckServer: ObservableObject {
                 "tmux_target": "\(DuckConfig.tmuxSession):\(DuckConfig.tmuxWindow).0",
             ]
             return .json(healthDict)
+        }
+
+        // GET /plugin-check?v=N — installed plugin reports its version
+        let checkPluginVersion: @Sendable (_ reported: Int) async -> Void = { reported in
+            await MainActor.run {
+                self.updateChecker?.checkRemotePluginVersion(reported)
+            }
+        }
+        srv.get("/plugin-check") { request in
+            let parts = request.path.components(separatedBy: "?")
+            let query = parts.count > 1 ? parts[1] : ""
+            let vStr = query.components(separatedBy: "=").last ?? "0"
+            let reported = Int(vStr) ?? 0
+            await checkPluginVersion(reported)
+            return .json("{\"status\":\"ok\"}".data(using: .utf8)!)
         }
 
         // GET / — dashboard

--- a/widget/Sources/RubberDuckWidget/DuckServer.swift
+++ b/widget/Sources/RubberDuckWidget/DuckServer.swift
@@ -60,6 +60,17 @@ class DuckServer: ObservableObject {
                 await permissionGate.resolve(decision: decision, suggestionIndex: index)
             }
         }
+
+        // When a permission request becomes active (first in queue or queue advances),
+        // deliver it locally so the widget voice-asks about it.
+        let transport = localTransport
+        Task {
+            await permissionGate.setOnBecameActive { [weak transport] event in
+                Task { @MainActor in
+                    transport?.deliverPermission(event)
+                }
+            }
+        }
     }
 
     // MARK: - Lifecycle
@@ -244,6 +255,17 @@ class DuckServer: ObservableObject {
 
             DuckLog.log("[permission] Request: \(toolName) → \"\(summary)\" (\(suggestions.count) options)")
 
+            // AskUserQuestion: read the question aloud and auto-allow.
+            // The actual answer goes through Claude Code's UI — the duck just gives a heads-up.
+            if toolName == "AskUserQuestion" {
+                let questionSpeech = parseAskUserQuestion(toolInput)
+                DuckLog.log("[permission] AskUserQuestion — reading aloud and auto-allowing")
+                await MainActor.run {
+                    localTransport.onSpeak?(questionSpeech)
+                }
+                return .json(try! JSONSerialization.data(withJSONObject: ["decision": "allow"]))
+            }
+
             // Broadcast pending to WebSocket clients
             let pendingEvent = PermissionEvent(
                 type: "permission",
@@ -255,13 +277,9 @@ class DuckServer: ObservableObject {
             )
             await broadcaster.broadcast(pendingEvent)
 
-            // Deliver locally so widget can voice-ask
-            await MainActor.run {
-                localTransport.deliverPermission(pendingEvent)
-            }
-
-            // Wait for voice response
-            let (decision, suggestionIndex) = await permissionGate.waitForDecision()
+            // Wait for voice response (blocks until this request's turn).
+            // The gate delivers locally via onBecameActive when this request is active.
+            let (decision, suggestionIndex) = await permissionGate.waitForDecision(event: pendingEvent)
 
             if decision == "timeout" {
                 DuckLog.log("[permission] Timeout — no response")
@@ -420,10 +438,11 @@ class DuckServer: ObservableObject {
         // Signal from PostToolUse hook — user approved via CLI (not voice).
         // Resolves the PermissionGate so the original /permission curl unblocks,
         // clears the voice gate, and updates the UI.
-        srv.post("/permission-clear") { [permissionGate, localTransport] _ in
-            DuckLog.log("[permission] CLI approval — tool succeeded, clearing permission state")
-            // Resolve the gate so /permission's blocked curl returns
-            await permissionGate.resolve(decision: "allow")
+        srv.post("/permission-clear") { [localTransport] _ in
+            DuckLog.log("[permission] PostToolUse — clearing UI state")
+            // Only clear UI state (thinking indicator, expression).
+            // Do NOT resolve the gate — the PermissionRequest hook's stdout
+            // handles the actual decision, and resolve() would drain queued requests.
             await MainActor.run {
                 localTransport.onClearThinking?()
             }
@@ -626,8 +645,13 @@ func summarizePermission(toolName: String, toolInput: Any) -> String {
         return "Claude wants to launch a sub-agent"
 
     default:
-        // MCP tools: mcp__server-name__tool_name → "Use a connector"
+        // MCP tools: mcp__server-name__tool_name → extract readable tool name
         if toolName.hasPrefix("mcp__") {
+            if let range = toolName.range(of: "__", options: .backwards) {
+                let toolPart = String(toolName[range.upperBound...])
+                    .replacingOccurrences(of: "_", with: " ")
+                if !toolPart.isEmpty { return toolPart }
+            }
             return "Use a connector"
         }
         // Any other unknown tool with underscores → generic fallback
@@ -697,5 +721,38 @@ private func summarizeBashCommand(_ command: String) -> String {
     case "echo":    return "Run a command"
     default:        return "Run a command"
     }
+}
+
+/// Parse AskUserQuestion tool_input into a speakable string.
+/// Reads the first question and its option labels.
+private func parseAskUserQuestion(_ toolInput: Any) -> String {
+    let dict: [String: Any]
+    if let d = toolInput as? [String: Any] {
+        dict = d
+    } else if let str = toolInput as? String,
+              let data = str.data(using: .utf8),
+              let d = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        dict = d
+    } else {
+        return "Claude has a question."
+    }
+
+    guard let questions = dict["questions"] as? [[String: Any]],
+          let firstQ = questions.first,
+          let question = firstQ["question"] as? String else {
+        return "Claude has a question."
+    }
+
+    let options = (firstQ["options"] as? [[String: Any]])?
+        .compactMap { $0["label"] as? String } ?? []
+
+    if options.isEmpty {
+        return question
+    }
+
+    let numbered = options.enumerated()
+        .map { "\($0.offset + 1): \($0.element)" }
+        .joined(separator: ". ")
+    return "\(question) Options: \(numbered)."
 }
 

--- a/widget/Sources/RubberDuckWidget/DuckView.swift
+++ b/widget/Sources/RubberDuckWidget/DuckView.swift
@@ -121,6 +121,15 @@ private struct DuckContextMenu: View {
             Label("Voice: \(voiceLabel)", systemImage: "waveform")
         }
 
+        Button {
+            DuckConfig.subtitlesEnabled.toggle()
+        } label: {
+            Label(
+                DuckConfig.subtitlesEnabled ? "✓ Show Subtitles" : "Show Subtitles",
+                systemImage: "captions.bubble"
+            )
+        }
+
         // Intelligence picker
         Menu {
             Button {
@@ -204,6 +213,7 @@ private struct DuckStatusOverlay: View {
 
     private var speechBubbleVisible: Bool {
         guard !speechService.currentUtterance.isEmpty else { return false }
+        if DuckConfig.subtitlesEnabled { return true }
         if speechService.isSilent || DuckConfig.volume <= 0 { return true }
         if speechService.audioPath == .local && AudioDeviceDiscovery.isSystemOutputMuted() {
             return true

--- a/widget/Sources/RubberDuckWidget/DuckView.swift
+++ b/widget/Sources/RubberDuckWidget/DuckView.swift
@@ -24,18 +24,6 @@ struct DuckView: View {
         }
         .frame(width: DuckTheme.widgetSize - 8, height: DuckTheme.widgetSize - 8)
         .contentShape(Rectangle())
-        .onTapGesture {
-            // Tap anywhere on the duck — stop speech or resume if paused.
-            // Uses static refs to avoid @EnvironmentObject on DuckView (which causes context menu flicker).
-            if let speech = AppDelegate.speechService, speech.isSpeaking {
-                DuckLog.log("[duck] Tap — stopping speech")
-                speech.stopSpeaking()
-                let quips = ["Nevermind.", "That's enough.", "Moving on.", "Ok ok.", "Shh."]
-                speech.speak(quips.randomElement()!, skipChirpWait: true)
-            } else if !AppDelegate.isDuckActive {
-                AppDelegate.turnOn()
-            }
-        }
         .onHover { hovering in
             withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
                 isHovering = hovering
@@ -71,7 +59,14 @@ private struct DuckContextMenu: View {
         Menu {
             Button {
                 speechService.ttsVoice = DuckVoices.wildcardSayName
-                speechService.speak("Wildcard mode. I'll pick a voice each time.", skipChirpWait: true)
+                speechService.scheduleSpeech(
+                    "Wildcard mode. I'll pick a voice each time.",
+                    kind: .preview,
+                    lane: .manual,
+                    policy: .latestWins,
+                    interruptibility: .freelyInterruptible,
+                    skipChirpWait: true
+                )
             } label: {
                 let active = speechService.isWildcardMode
                 Label(active ? "✓ Wildcard (AI picks)" : "Wildcard (AI picks)", systemImage: "shuffle")
@@ -84,7 +79,15 @@ private struct DuckContextMenu: View {
                 ForEach([DuckVoices.main, DuckVoices.classic, DuckVoices.specialFX, DuckVoices.british][groupIdx], id: \.sayName) { voice in
                     Button {
                         speechService.ttsVoice = voice.sayName
-                        speechService.speak(voice.preview, skipChirpWait: true)
+                        speechService.scheduleSpeech(
+                            voice.preview,
+                            kind: .preview,
+                            lane: .manual,
+                            scopeID: "voice-preview",
+                            policy: .latestWins,
+                            interruptibility: .freelyInterruptible,
+                            skipChirpWait: true
+                        )
                     } label: {
                         Text(speechService.ttsVoice == voice.sayName && !speechService.isWildcardMode ? "✓ \(voice.label)" : voice.label)
                     }
@@ -138,6 +141,20 @@ private struct DuckContextMenu: View {
         }
 
         Divider()
+
+        if AppDelegate.isDuckActive {
+            Button {
+                AppDelegate.turnOff()
+            } label: {
+                Label("Pause", systemImage: "pause.fill")
+            }
+        } else {
+            Button {
+                AppDelegate.turnOn()
+            } label: {
+                Label("Resume", systemImage: "play.fill")
+            }
+        }
 
         Button {
             duckServer.stop()
@@ -486,21 +503,8 @@ private struct DuckWingsView: View {
                 .scaleEffect(x: -1, y: 1)
                 .offset(x: 16, y: wingsVisible ? 32 : 60)
                 .opacity(wingsVisible ? 1 : 0)
-            // Tap target — covers full widget width at wing height
-            Color.clear
-                .frame(width: DuckTheme.widgetSize, height: 70)
-                .contentShape(Rectangle())
-                .allowsHitTesting(wingsVisible)
-                .onTapGesture {
-                    if speechService.isSpeaking {
-                        DuckLog.log("[duck] Wing tap — stopping speech")
-                        speechService.stopSpeaking()
-                    } else if !AppDelegate.isDuckActive {
-                        AppDelegate.turnOn()
-                    }
-                }
-                .offset(y: 20)
         }
+        .allowsHitTesting(false)
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: isHovering)
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: speechService.isSpeaking)
         .animation(.spring(response: 0.35, dampingFraction: 0.7), value: AppDelegate.isDuckActive)

--- a/widget/Sources/RubberDuckWidget/DuckView.swift
+++ b/widget/Sources/RubberDuckWidget/DuckView.swift
@@ -42,6 +42,27 @@ private struct DuckContextMenu: View {
     @EnvironmentObject var duckServer: DuckServer
 
     var body: some View {
+        // Update notifications (top of menu)
+        if coordinator.isAppUpdateAvailable, let version = coordinator.appUpdateVersion {
+            Button {
+                if let urlStr = coordinator.appUpdateURL, let url = URL(string: urlStr) {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Label("Update Available: v\(version)", systemImage: "arrow.down.circle")
+            }
+        }
+        if coordinator.isPluginStale {
+            Button {
+                PluginInstaller.install()
+            } label: {
+                Label("Plugin Update Available", systemImage: "puzzlepiece.extension.fill")
+            }
+        }
+        if coordinator.isAppUpdateAvailable || coordinator.isPluginStale {
+            Divider()
+        }
+
         // Mode selector
         Menu {
             ForEach(DuckMode.allCases, id: \.rawValue) { mode in

--- a/widget/Sources/RubberDuckWidget/HelpView.swift
+++ b/widget/Sources/RubberDuckWidget/HelpView.swift
@@ -43,15 +43,16 @@ struct HelpView: View {
                 The plugin checks your Claude version automatically. If it's too old, \
                 you'll be prompted to update.
 
-                **Using Claude Desktop instead of CLI?** Export the plugin zip from \
+                **Using Claude Desktop instead of CLI?** Fully supported. Export the plugin zip from \
                 Setup → Export Plugin Zip, then upload it via Claude Desktop's plugin manager.
 
-                No config files. No API keys required. Eval runs on-device for free.
+                No config files. No API keys required. Eval runs on-device for free. \
+                He's watching before you've finished reading this.
                 """)
 
                 section("Modes", """
                 **Permissions Only** — Silent watchdog. He only speaks up when Claude \
-                needs permission to do something. Listens for "yes" or "no" — that's it. \
+                needs permission to do something. Listens for "yes", "no", or "always allow" — that's it. \
                 The strong, silent type.
 
                 **Companion** — The full experience. Opinions, permissions, voice control. \
@@ -69,6 +70,15 @@ struct HelpView: View {
                 Preferences → Behavior tab.
                 """)
 
+                section("Talk to the Duck", """
+                Say "ducky" followed by a question about the duck itself — setup, \
+                modes, features, troubleshooting — and he'll answer in character. \
+                Powered by on-device Foundation Models, so it's free and private. \
+                He keeps context across follow-ups, so "tell me more" works.
+
+                He also has a backstory. He won't tell you willingly.
+                """)
+
                 section("Microphone & Audio", """
                 Yes, he can hear you. He uses your Mac's mic to listen for \
                 voice commands — all processed locally on your Mac. Nothing leaves the device.
@@ -76,7 +86,7 @@ struct HelpView: View {
                 **What he listens for depends on the mode:**
                 • Companion: the wake word "ducky", then your question or command
                 • Relay: "ducky" followed by commands for Claude Code
-                • Permissions Only: "yes" or "no" when Claude asks permission
+                • Permissions Only: "yes", "no", or "always allow" when Claude asks permission
                 • No Mic: nothing. Mic is completely off.
 
                 **Microphone selection:** Open Preferences → Behavior → Microphone \
@@ -107,8 +117,19 @@ struct HelpView: View {
                 Apple Foundation Model automatically. You won't miss a beat.
                 """)
 
+                section("Reading His Face", """
+                His face reacts to the scores in real time.
+
+                Wide round eyes? He's impressed. Squinting? Suspicious. \
+                Exclamation marks for eyes? Claude needs permission and the duck \
+                needs your attention. A warm amber glow means he likes what he \
+                sees. Cool blue means he doesn't.
+                """)
+
                 section("Menus", """
-                **Menu bar icon (🦆)** — Quick access to Volume, Mode, Voice, \
+                Everything you need to control a duck.
+
+                **Menu bar icon (🦆)** — Volume, Mode, Voice, \
                 Intelligence, Launch Claude Code, Pause/Resume, and Quit. \
                 Right-click the duck widget for the same menu.
 
@@ -119,7 +140,9 @@ struct HelpView: View {
                 """)
 
                 section("Preferences", """
-                Open with **⌘,** or from the Duck Duck Duck menu.
+                Open with **⌘,** or from the Duck Duck Duck menu. \
+                Most of these are set-and-forget — he has defaults and he's \
+                confident in them.
 
                 **Intelligence** — Pick the eval provider. Apple Foundation Model is free \
                 and fully private (runs on your Mac). Claude Haiku and Gemini are sharper \
@@ -127,17 +150,11 @@ struct HelpView: View {
 
                 **Behavior** — Mode selection, voice picker, volume slider, and \
                 microphone settings. See which mic is active, check permission status, \
-                and pick a device if you have multiple.
+                and pick a device if you have multiple. **Wildcard** lets the AI pick \
+                from 10 voices per reaction based on the scores — toggle it from the \
+                right-click menu or Preferences.
 
                 **About** — Credits and GitHub link.
-                """)
-
-                section("Stopping Speech", """
-                Hover over the duck while it's speaking — wings slide up over the beak. \
-                Tap to stop. He'll say a short quip and move on.
-
-                Works for anything: eval reactions, help answers, even the bedtime story. \
-                If he's mid-sentence about your code quality, one tap shuts him up.
                 """)
 
                 section("Tips", """
@@ -147,15 +164,22 @@ struct HelpView: View {
                 Your hands stay free.
                 • If eval feels slow, switch to Foundation Model. Free, private, instant.
                 • Right-click the duck for quick settings.
+                • Hear a familiar theme song? Claude is compacting context. He's thinking.
                 • Ducks have weird hole-shaped ears. Now you know.
 
                 **Plugin not working?** Make sure Claude is updated to **version 1.1.7714 \
                 or newer**. Older versions had bugs with plugin hooks — the duck shows up \
                 in the plugin list but doesn't actually fire. Update Claude, start a fresh \
                 session, and he'll wake right up.
+
+                If you updated the plugin mid-session, run `/reload-plugins` in Claude \
+                to pick up changes without restarting.
                 """)
 
                 section("Privacy", """
+                By default, nothing leaves your Mac. Not your code, not your \
+                voice, not his opinions.
+
                 **Apple Foundation Model** — All scoring runs on your Mac. Your prompts, \
                 Claude's responses, and all audio stay on the device. Nothing is sent anywhere.
 

--- a/widget/Sources/RubberDuckWidget/MiniServer.swift
+++ b/widget/Sources/RubberDuckWidget/MiniServer.swift
@@ -381,8 +381,9 @@ final class MiniServer {
             return
         }
 
-        // Match registered route
-        for r in routes where r.method == request.method && r.path == request.path {
+        // Match registered route (strip query string for comparison)
+        let pathOnly = request.path.components(separatedBy: "?").first ?? request.path
+        for r in routes where r.method == request.method && r.path == pathOnly {
             let handler = r.handler
             Task {
                 let response = await handler(request)

--- a/widget/Sources/RubberDuckWidget/PermissionGate.swift
+++ b/widget/Sources/RubberDuckWidget/PermissionGate.swift
@@ -1,7 +1,8 @@
 // Permission Gate — Voice-gated permission approval for Claude Code actions.
 //
-// Uses CheckedContinuation for async blocking until the widget sends a
-// voice response (allow/deny). Timeout after 30s if no response.
+// Uses a FIFO queue so concurrent permission requests each block independently.
+// The duck asks about the head of the queue; when resolved, the next one
+// becomes active and the duck asks about it.
 //
 // Timeout uses DispatchQueue instead of Task.sleep to avoid the
 // swift_task_dealloc crash that occurs with Task.sleep(for:) in
@@ -11,56 +12,88 @@ import Foundation
 
 actor PermissionGate {
 
-    private var continuation: CheckedContinuation<(String, Int?), Never>?
-    private var timeoutWorkItem: DispatchWorkItem?
+    private struct PendingRequest {
+        let id: UUID
+        let continuation: CheckedContinuation<(String, Int?), Never>
+        let timeoutWorkItem: DispatchWorkItem
+    }
+
+    private var queue: [PendingRequest] = []
+
+    /// Called when a request becomes the active (head) request and needs voice-asking.
+    /// Fires both for the first request and when the queue advances.
+    private var onBecameActive: ((PermissionEvent) -> Void)?
+
+    func setOnBecameActive(_ handler: @escaping (PermissionEvent) -> Void) {
+        onBecameActive = handler
+    }
+
+    /// Stored permission events, keyed by request ID, for delivery when active.
+    private var pendingEvents: [UUID: PermissionEvent] = [:]
 
     // MARK: - Wait / Resolve
 
-    /// Block until the widget sends a permission response, or timeout.
-    /// Returns (decision, suggestionIndex) where decision is "allow", "deny", or "timeout".
-    func waitForDecision(timeoutSeconds: Double = 30.0) async -> (String, Int?) {
-        // Cancel any stale pending request
-        timeoutWorkItem?.cancel()
-        timeoutWorkItem = nil
-        if let old = continuation {
-            continuation = nil
-            old.resume(returning: ("timeout", nil))
+    /// Block until this request is resolved or times out.
+    /// Requests are queued FIFO — each caller blocks independently.
+    /// When this request is first in queue, `onBecameActive` fires immediately
+    /// to trigger the duck's voice prompt. Otherwise it fires when the queue advances.
+    func waitForDecision(timeoutSeconds: Double = 30.0, event: PermissionEvent) async -> (String, Int?) {
+        let requestID = UUID()
+        let isFirst = queue.isEmpty
+
+        pendingEvents[requestID] = event
+
+        // If first in queue, trigger the voice prompt immediately
+        if isFirst {
+            onBecameActive?(event)
         }
 
         let result = await withCheckedContinuation { (cont: CheckedContinuation<(String, Int?), Never>) in
-            continuation = cont
-
-            // Use GCD for timeout — avoids swift_task_dealloc crash from Task.sleep
             let workItem = DispatchWorkItem { [weak self] in
-                Task { await self?.handleTimeout() }
+                Task { await self?.handleTimeout(requestID: requestID) }
             }
-            timeoutWorkItem = workItem
+            let pending = PendingRequest(id: requestID, continuation: cont, timeoutWorkItem: workItem)
+            queue.append(pending)
             DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: workItem)
         }
 
+        pendingEvents.removeValue(forKey: requestID)
         return result
     }
 
     /// Called when the widget sends a permission response via WebSocket or local transport.
+    /// Resolves the head of the queue (the currently active request).
     func resolve(decision: String, suggestionIndex: Int? = nil) {
+        guard !queue.isEmpty else { return }
+
         let validDecision = (decision == "allow" || decision == "deny") ? decision : "deny"
         DuckLog.log("[permission] Resolved: \(validDecision), suggestion_index=\(String(describing: suggestionIndex))")
 
-        timeoutWorkItem?.cancel()
-        timeoutWorkItem = nil
+        let head = queue.removeFirst()
+        head.timeoutWorkItem.cancel()
+        head.continuation.resume(returning: (validDecision, suggestionIndex))
 
-        if let cont = continuation {
-            continuation = nil
-            cont.resume(returning: (validDecision, suggestionIndex))
-        }
+        activateNextIfNeeded()
     }
 
-    private func handleTimeout() {
-        guard let cont = continuation else { return }
-        DuckLog.log("[permission] Timeout — no response from widget")
-        continuation = nil
-        timeoutWorkItem = nil
-        cont.resume(returning: ("timeout", nil))
+    private func handleTimeout(requestID: UUID) {
+        guard let idx = queue.firstIndex(where: { $0.id == requestID }) else { return }
+
+        let wasHead = (idx == 0)
+        let entry = queue.remove(at: idx)
+        pendingEvents.removeValue(forKey: requestID)
+
+        DuckLog.log("[permission] Timeout for request \(requestID.uuidString.prefix(8))")
+        entry.continuation.resume(returning: ("timeout", nil))
+
+        if wasHead { activateNextIfNeeded() }
+    }
+
+    private func activateNextIfNeeded() {
+        guard let nextRequest = queue.first,
+              let event = pendingEvents[nextRequest.id] else { return }
+        DuckLog.log("[permission] Activating next in queue — \(queue.count) remaining")
+        onBecameActive?(event)
     }
 
     // MARK: - Suggestion Labels

--- a/widget/Sources/RubberDuckWidget/PermissionVoiceGate.swift
+++ b/widget/Sources/RubberDuckWidget/PermissionVoiceGate.swift
@@ -36,10 +36,11 @@ struct PermissionVoiceGate {
     var fullPrompt = ""
 
     // Word sets for matching
+    // Includes common STT misrecognitions of "allow" (e.g. "aloud", "a loud")
     private let affirmatives: Set<String> = [
         "yes", "yeah", "yep", "yup", "sure", "allow", "approve", "okay",
         "proceed", "accepted", "affirmative", "correct", "fine", "granted",
-        "go", "do", "ahead",
+        "go", "do", "ahead", "aloud", "allowed", "loud",
     ]
     private let negatives: Set<String> = [
         "no", "nope", "deny", "block", "stop", "cancel", "reject",
@@ -118,15 +119,19 @@ struct PermissionVoiceGate {
         return .noMatch
     }
 
-    /// Find the first option label that contains "always allow" (case-insensitive).
+    /// Find the best "always allow" option.
+    /// Prefers the last matching label — Claude Code typically puts the broadest
+    /// (most useful) "always allow" suggestion last, and narrower read-path
+    /// rules first. Falling back to the last option if none match explicitly.
     private func findAlwaysAllowOption() -> Int? {
+        var lastMatch: Int?
         for (i, label) in optionLabels.enumerated() {
             if label.lowercased().contains("always allow") {
-                return i + 1  // 1-based
+                lastMatch = i + 1  // 1-based
             }
         }
-        // Fall back to first option if none match
-        return optionCount > 0 ? 1 : nil
+        // Fall back to last option — more likely to be the tool-level rule
+        return lastMatch ?? (optionCount > 0 ? optionCount : nil)
     }
 
     /// Begin waiting for a permission response.

--- a/widget/Sources/RubberDuckWidget/PreferencesView.swift
+++ b/widget/Sources/RubberDuckWidget/PreferencesView.swift
@@ -454,12 +454,21 @@ private struct BehaviorPane: View {
 // MARK: - About Pane
 
 private struct AboutPane: View {
+    @EnvironmentObject var coordinator: DuckCoordinator
+
+    private var currentVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
     var body: some View {
         Form {
             Section {
                 VStack(spacing: 8) {
                     Text("Duck Duck Duck")
                         .font(.title2.bold())
+                    Text("v\(currentVersion)")
+                        .font(.subheadline.monospacedDigit())
+                        .foregroundStyle(.secondary)
                     Text("Built at IDEO by some mighty ducks.")
                         .foregroundStyle(.secondary)
                     Link("GitHub", destination: URL(string: "https://github.com/ideo/Rubber-Duck")!)
@@ -467,6 +476,35 @@ private struct AboutPane: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 8)
+            }
+
+            if coordinator.isAppUpdateAvailable, let version = coordinator.appUpdateVersion {
+                Section {
+                    HStack {
+                        Image(systemName: "arrow.down.circle")
+                            .foregroundStyle(.orange)
+                        Text("v\(version) available")
+                        Spacer()
+                        if let urlStr = coordinator.appUpdateURL, let url = URL(string: urlStr) {
+                            Link("Download", destination: url)
+                                .foregroundColor(.accentColor)
+                        }
+                    }
+                }
+            }
+
+            if coordinator.isPluginStale {
+                Section {
+                    HStack {
+                        Image(systemName: "puzzlepiece.extension.fill")
+                            .foregroundStyle(.orange)
+                        Text("Plugin update available")
+                        Spacer()
+                        Button("Update Plugin") {
+                            PluginInstaller.install()
+                        }
+                    }
+                }
             }
         }
         .formStyle(.grouped)

--- a/widget/Sources/RubberDuckWidget/PreferencesView.swift
+++ b/widget/Sources/RubberDuckWidget/PreferencesView.swift
@@ -320,12 +320,35 @@ private struct BehaviorPane: View {
                     speechService.ttsVoice = selectedVoice
                     if selectedVoice == DuckVoices.wildcardSayName {
                         speechService.setVoiceTransient(DuckVoices.wildcardDefault.sayName)
-                        speechService.speak("Wildcard mode.", skipChirpWait: true)
+                        speechService.scheduleSpeech(
+                            "Wildcard mode.",
+                            kind: .preview,
+                            lane: .manual,
+                            scopeID: "voice-preview",
+                            policy: .latestWins,
+                            interruptibility: .freelyInterruptible,
+                            skipChirpWait: true
+                        )
                     } else if selectedVoice == DuckVoices.silentSayName {
-                        speechService.speak("Silent mode. Speech bubbles only.")
+                        speechService.scheduleSpeech(
+                            "Silent mode. Speech bubbles only.",
+                            kind: .preview,
+                            lane: .manual,
+                            scopeID: "voice-preview",
+                            policy: .latestWins,
+                            interruptibility: .freelyInterruptible
+                        )
                     } else {
                         let voice = DuckVoices.all.first { $0.sayName == selectedVoice }
-                        speechService.speak(voice?.preview ?? "This is how I sound.", skipChirpWait: true)
+                        speechService.scheduleSpeech(
+                            voice?.preview ?? "This is how I sound.",
+                            kind: .preview,
+                            lane: .manual,
+                            scopeID: "voice-preview",
+                            policy: .latestWins,
+                            interruptibility: .freelyInterruptible,
+                            skipChirpWait: true
+                        )
                     }
                 }
 

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -139,22 +139,41 @@ struct RubberDuckWidgetApp: App {
             // Everything else → duck handles it (help, chat, anything)
             Task {
                 await MainActor.run {
-                    speech.speak(["Hmm...", "Let me think...", "One sec..."].randomElement()!, skipChirpWait: true)
+                    let turnScope = speech.currentTurnScopeID ?? speech.nextTurnScopeID()
+                    speech.scheduleSpeech(
+                        ["Hmm...", "Let me think...", "One sec..."].randomElement()!,
+                        kind: .filler,
+                        lane: .turn,
+                        scopeID: turnScope,
+                        policy: .replaceScope,
+                        interruptibility: .freelyInterruptible,
+                        skipChirpWait: true
+                    )
                 }
                 let answer = await helpService.ask(text)
                 await MainActor.run {
                     speech.isWakeActive = false
+                    let turnScope = speech.currentTurnScopeID ?? speech.nextTurnScopeID()
                     if answer == DuckHelpService.fullStoryReadingSentinel {
                         // Fully shut down conversation state before the long story read
                         speech.exitConversation()
-                        // Read the full Moby Duck story via TTS — no LLM, just reading aloud
-                        speech.speak("Alright. Settle in. ... " + DuckHelpService.fullStoryText)
-                        speech.restartAfterTTS(thenEnterConversation: false)
+                        let storyChunks = ["Alright. Settle in."] + DuckHelpService.fullStoryText
+                            .components(separatedBy: " ... ")
+                            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                            .filter { !$0.isEmpty }
+                        speech.scheduleScript(texts: storyChunks, scopeID: speech.nextScriptScopeID(prefix: "story"))
                         // Story told — fully reset backstory so next question goes back to normal help
                         Task { await helpService.resetBackstoryCompletely() }
                     } else {
-                        speech.speak(answer ?? "Not sure about that one.")
-                        speech.restartAfterTTS(thenEnterConversation: true)
+                        speech.scheduleSpeech(
+                            answer ?? "Not sure about that one.",
+                            kind: .answer,
+                            lane: .turn,
+                            scopeID: turnScope,
+                            policy: .replaceScope,
+                            interruptibility: .byCriticalOnly,
+                            onFinish: speech.makeListeningCompletionAction(enterConversation: true)
+                        )
                     }
                 }
             }
@@ -195,7 +214,15 @@ struct RubberDuckWidgetApp: App {
         }
 
         // Wire plugin installer voice feedback
-        PluginInstaller.onSpeak = { [weak speech] text in speech?.speak(text) }
+        PluginInstaller.onSpeak = { [weak speech] text in
+            speech?.scheduleSpeech(
+                text,
+                kind: .system,
+                lane: .manual,
+                policy: .latestWins,
+                interruptibility: .freelyInterruptible
+            )
+        }
 
         // Store service refs so AppDelegate can turn off the companion
         AppDelegate.speechService = speech
@@ -211,7 +238,15 @@ struct RubberDuckWidgetApp: App {
 
         // Wire lifecycle hooks from DuckServer → coordinator
         let transport = server.localTransport
-        transport.onSpeak = { [weak speech] text in speech?.speak(text) }
+        transport.onSpeak = { [weak speech] text in
+            speech?.scheduleSpeech(
+                text,
+                kind: .system,
+                lane: .ambient,
+                policy: .dropIfBusy,
+                interruptibility: .freelyInterruptible
+            )
+        }
         transport.onClearThinking = { [weak coordinator] in coordinator?.clearThinking() }
         transport.onMelodyStart = { [weak coordinator] in coordinator?.startMelody() }
         transport.onMelodyStop = { [weak coordinator] in coordinator?.stopMelody() }
@@ -219,7 +254,13 @@ struct RubberDuckWidgetApp: App {
         // TTS greeting when a Claude session connects via /health
         server.onSessionConnect = { [weak speech, weak coordinator] in
             let mode = coordinator?.mode ?? .companion
-            speech?.speak(LaunchGreeting.sessionConnect(mode: mode))
+            speech?.scheduleSpeech(
+                LaunchGreeting.sessionConnect(mode: mode),
+                kind: .greeting,
+                lane: .ambient,
+                policy: .dropIfBusy,
+                interruptibility: .freelyInterruptible
+            )
         }
 
         // Wait for permissions, then apply saved listen mode + greet
@@ -228,7 +269,13 @@ struct RubberDuckWidgetApp: App {
             speech.refreshPermissionStatus()
             if speech.micPermissionGranted && speech.speechPermissionGranted {
                 speech.applyListenMode()
-                speech.speak(LaunchGreeting.pick(mode: coordinator.mode))
+                speech.scheduleSpeech(
+                    LaunchGreeting.pick(mode: coordinator.mode),
+                    kind: .greeting,
+                    lane: .ambient,
+                    policy: .dropIfBusy,
+                    interruptibility: .freelyInterruptible
+                )
                 return
             }
             // Otherwise poll (waiting for user to grant via dialog)
@@ -237,7 +284,13 @@ struct RubberDuckWidgetApp: App {
                 speech.refreshPermissionStatus()
                 if speech.micPermissionGranted && speech.speechPermissionGranted {
                     speech.applyListenMode()
-                    speech.speak(LaunchGreeting.pick(mode: coordinator.mode))
+                    speech.scheduleSpeech(
+                        LaunchGreeting.pick(mode: coordinator.mode),
+                        kind: .greeting,
+                        lane: .ambient,
+                        policy: .dropIfBusy,
+                        interruptibility: .freelyInterruptible
+                    )
                     return
                 }
             }
@@ -364,8 +417,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        // Kill any lingering TTS — say process outlives the app
-        Process.launchedProcess(launchPath: "/usr/bin/killall", arguments: ["say"])
+        // Stop owned TTS sessions cleanly before shutdown.
+        Task { @MainActor in
+            Self.speechService?.stopSpeaking(reason: .shutdown)
+        }
         // Clean up port file so hooks don't try a stale port
         DuckConfig.removePortFile()
     }
@@ -395,7 +450,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard isDuckActive else { return }
         isDuckActive = false
         speechService?.stopListening()
-        speechService?.stopSpeaking()
+        speechService?.stopSpeaking(reason: .userCancelled)
         coordinator?.clearThinking()
         DuckLog.log("[app] Duck Duck Duck turned off")
     }

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -366,12 +366,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 NSApp.activate()
             }
         }
+        // Mark any new windows as non-restorable (Help, Settings created on demand)
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main
+        ) { notif in
+            (notif.object as? NSWindow)?.isRestorable = false
+        }
+
         // Strip useless default menus — SwiftUI recreates them on window focus,
         // so we observe changes and strip continuously.
         Self.startMenuStripping()
 
-        // Disable state restoration — it recreates windows without our properties
-        UserDefaults.standard.removeObject(forKey: "NSWindow Frame main")
+        // Disable state restoration — it recreates windows without our properties.
+        // Clear ALL window frame autosaves, not just "main".
+        for key in UserDefaults.standard.dictionaryRepresentation().keys where key.hasPrefix("NSWindow Frame") {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
         UserDefaults.standard.removeObject(forKey: "NSWindowAutosaveFrames")
 
         // Ensure app is a regular dock app (not background agent)

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -94,6 +94,7 @@ struct RubberDuckWidgetApp: App {
         Settings {
             PreferencesView()
                 .environmentObject(speechService)
+                .environmentObject(coordinator)
         }
     }
 
@@ -235,6 +236,41 @@ struct RubberDuckWidgetApp: App {
             serialManager: serial,
             duckServer: server
         )
+
+        // Update checker — polls GitHub Releases API
+        let updateChecker = UpdateChecker()
+        statusBarManager?.updateChecker = updateChecker
+        server.updateChecker = updateChecker
+
+        updateChecker.onUpdateDetected = { [weak speech, weak coordinator] release in
+            coordinator?.isAppUpdateAvailable = true
+            coordinator?.appUpdateVersion = release.version
+            coordinator?.appUpdateURL = release.dmgURL ?? release.htmlURL
+            speech?.scheduleSpeech(
+                "Hey, there's a newer version of me on GitHub!",
+                kind: .system,
+                lane: .ambient,
+                policy: .dropIfBusy,
+                interruptibility: .freelyInterruptible
+            )
+        }
+        updateChecker.onPluginStale = { [weak speech, weak coordinator] in
+            coordinator?.isPluginStale = true
+            speech?.scheduleSpeech(
+                "My plugin needs updating. Check the menu.",
+                kind: .system,
+                lane: .ambient,
+                policy: .dropIfBusy,
+                interruptibility: .freelyInterruptible
+            )
+        }
+
+        // Detect app version change → check plugin staleness
+        if updateChecker.detectAppVersionChange() {
+            updateChecker.detectPluginStaleness()
+        }
+
+        updateChecker.startPeriodicChecks()
 
         // Wire lifecycle hooks from DuckServer → coordinator
         let transport = server.localTransport

--- a/widget/Sources/RubberDuckWidget/SerialTTSEngine.swift
+++ b/widget/Sources/RubberDuckWidget/SerialTTSEngine.swift
@@ -8,6 +8,12 @@ import AVFoundation
 
 @MainActor
 class SerialTTSEngine {
+    private struct PlaybackSession {
+        let id: UUID
+        let completion: TTSPlaybackCompletion
+        var stopReason: TTSStopReason?
+    }
+
     /// Shared gate for muting mic input during TTS playback.
     let gate = TTSGate()
 
@@ -20,7 +26,8 @@ class SerialTTSEngine {
     private let synth = AVSpeechSynthesizer()
     private weak var transport: SerialTransport?
     private var streamingTask: Task<Void, Never>?
-    private var isStopping = false
+    private var activeSessionID: UUID?
+    private var sessions: [UUID: PlaybackSession] = [:]
 
     private func log(_ msg: String) { DuckLog.log(msg) }
 
@@ -30,11 +37,9 @@ class SerialTTSEngine {
 
     /// Speak text by streaming PCM to the ESP32 over serial.
     /// Set `skipChirpWait` to true when no chirp was triggered (e.g. voice preview).
-    func speak(_ text: String, skipChirpWait: Bool = false) {
+    func play(_ text: String, utteranceID: UUID, skipChirpWait: Bool = false, completion: @escaping TTSPlaybackCompletion) {
         guard !text.isEmpty, let transport = transport else { return }
         log("[serial-tts] \(text)")
-
-        stop()
 
         var cleaned = text
             .replacingOccurrences(of: "**", with: "")
@@ -59,12 +64,12 @@ class SerialTTSEngine {
         }
 
         gate.muted = true
-        isStopping = false
+        activeSessionID = utteranceID
+        sessions[utteranceID] = PlaybackSession(id: utteranceID, completion: completion, stopReason: nil)
 
         // DON'T enter audio mode yet — let the chirp play first.
         // Audio mode entry happens in the streaming task after a delay.
 
-        let g = gate
         let transportRef = transport
 
         let engine = self
@@ -77,8 +82,14 @@ class SerialTTSEngine {
             if shouldWaitForChirp {
                 await SerialTTSEngine.waitForChirpDone(transport: transportRef)
             }
+            if let stopReason = await engine.stopReason(for: utteranceID) {
+                await MainActor.run { engine.sendEndOfStream() }
+                await engine.finishSession(utteranceID, defaultResult: .cancelled(stopReason))
+                return
+            }
             guard !Task.isCancelled else {
                 await MainActor.run { engine.sendEndOfStream() }
+                await engine.finishSession(utteranceID, defaultResult: .cancelled(.replaced))
                 return
             }
 
@@ -152,22 +163,41 @@ class SerialTTSEngine {
 
             // Brief delay for ESP32 ring buffer to drain, then unmute mic
             try? await Task.sleep(nanoseconds: 300_000_000)
-            g.muted = false
+            if let stopReason = await engine.stopReason(for: utteranceID) {
+                await engine.finishSession(utteranceID, defaultResult: .cancelled(stopReason))
+            } else {
+                await engine.finishSession(utteranceID, defaultResult: .finished)
+            }
         }
     }
 
     /// Stop current speech.
-    func stop() {
-        isStopping = true
+    func stopPlayback(reason: TTSStopReason) {
+        guard let activeSessionID, var session = sessions[activeSessionID] else { return }
+        session.stopReason = reason
+        sessions[activeSessionID] = session
         streamingTask?.cancel()
         streamingTask = nil
         synth.stopSpeaking(at: .immediate)
         sendEndOfStream()
-        gate.muted = false
     }
 
     /// Whether TTS is currently muting the mic.
     var isMuted: Bool { gate.muted }
+
+    private func stopReason(for sessionID: UUID) -> TTSStopReason? {
+        sessions[sessionID]?.stopReason
+    }
+
+    private func finishSession(_ sessionID: UUID, defaultResult: TTSPlaybackResult) {
+        guard let session = sessions.removeValue(forKey: sessionID) else { return }
+        let result = session.stopReason.map(TTSPlaybackResult.cancelled) ?? defaultResult
+        if activeSessionID == sessionID {
+            activeSessionID = nil
+            gate.muted = false
+        }
+        session.completion(sessionID, result)
+    }
 
     // MARK: - Chirp Wait
 

--- a/widget/Sources/RubberDuckWidget/SpeechService.swift
+++ b/widget/Sources/RubberDuckWidget/SpeechService.swift
@@ -42,6 +42,52 @@ enum ListenMode: Int, CaseIterable {
     }
 }
 
+enum SpeechLane: Int {
+    case critical = 0
+    case script = 1
+    case turn = 2
+    case manual = 3
+    case ambient = 4
+}
+
+enum SpeechKind {
+    case permission
+    case answer
+    case filler
+    case acknowledgement
+    case reaction
+    case greeting
+    case preview
+    case scriptStep
+    case system
+}
+
+enum SpeechPolicy {
+    case fifo
+    case latestWins
+    case replaceScope
+    case dropIfBusy
+    case exclusiveSession
+}
+
+enum SpeechInterruptibility {
+    case byCriticalOnly
+    case byUserAction
+    case freelyInterruptible
+}
+
+private struct ScheduledSpeech {
+    let id: UUID
+    let text: String
+    let lane: SpeechLane
+    let kind: SpeechKind
+    let scopeID: String?
+    let policy: SpeechPolicy
+    let interruptibility: SpeechInterruptibility
+    let skipChirpWait: Bool
+    let onFinish: (@MainActor () -> Void)?
+}
+
 @MainActor
 class SpeechService: ObservableObject {
     // Published state
@@ -129,7 +175,19 @@ class SpeechService: ObservableObject {
     private var voiceInputTimer: Task<Void, Never>?
     private var deviceCheckTask: Task<Void, Never>?
     private var utteranceClearTimer: Task<Void, Never>?
+    private var simulatedSpeechTask: Task<Void, Never>?
 
+    // Speech scheduling
+    private var activeSpeech: ScheduledSpeech?
+    private var activePlaybackBackend: (any TTSBackend)?
+    private var criticalQueue: [ScheduledSpeech] = []
+    private var scriptQueue: [ScheduledSpeech] = []
+    private var pendingTurnSpeech: ScheduledSpeech?
+    private var pendingManualSpeech: ScheduledSpeech?
+    private var pendingAmbientSpeech: ScheduledSpeech?
+    private var turnCounter: Int = 0
+    private var scriptCounter: Int = 0
+    private(set) var currentTurnScopeID: String?
 
     init() {
         stt = STTEngine()
@@ -381,61 +439,286 @@ class SpeechService: ObservableObject {
     /// Whether the current voice is Silent (speech bubble only, no TTS).
     var isSilent: Bool { ttsVoice == DuckVoices.silentSayName }
 
-    private var speakingPollTimer: Task<Void, Never>?
-
     func speak(_ text: String, skipChirpWait: Bool = false) {
-        currentUtterance = text
-        utteranceClearTimer?.cancel()
-        utteranceClearTimer = Task {
-            // Reading time: 2s base notice time + ~50ms per character (~200 WPM).
-            // Matches comfortable reading pace with time to notice the bubble.
-            let duration = 2.0 + Double(text.count) * 0.05
-            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
-            if !Task.isCancelled {
-                await MainActor.run { self.currentUtterance = "" }
-            }
+        scheduleSpeech(
+            text,
+            kind: .system,
+            lane: .manual,
+            policy: .latestWins,
+            interruptibility: .freelyInterruptible,
+            skipChirpWait: skipChirpWait
+        )
+    }
+
+    func scheduleSpeech(
+        _ text: String,
+        kind: SpeechKind,
+        lane: SpeechLane,
+        scopeID: String? = nil,
+        policy: SpeechPolicy,
+        interruptibility: SpeechInterruptibility,
+        skipChirpWait: Bool = false,
+        onFinish: (@MainActor () -> Void)? = nil
+    ) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let speech = ScheduledSpeech(
+            id: UUID(),
+            text: trimmed,
+            lane: lane,
+            kind: kind,
+            scopeID: scopeID,
+            policy: policy,
+            interruptibility: interruptibility,
+            skipChirpWait: skipChirpWait,
+            onFinish: onFinish
+        )
+        enqueueSpeech(speech)
+    }
+
+    func nextTurnScopeID() -> String {
+        turnCounter += 1
+        return "turn-\(turnCounter)"
+    }
+
+    func nextScriptScopeID(prefix: String = "script") -> String {
+        scriptCounter += 1
+        return "\(prefix)-\(scriptCounter)"
+    }
+
+    func scheduleScript(
+        texts: [String],
+        scopeID: String? = nil,
+        interruptibility: SpeechInterruptibility = .byUserAction
+    ) {
+        let cleaned = texts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !cleaned.isEmpty else { return }
+
+        let scriptID = scopeID ?? nextScriptScopeID()
+        scriptQueue.removeAll()
+        pendingTurnSpeech = nil
+        pendingManualSpeech = nil
+        pendingAmbientSpeech = nil
+        if let activeSpeech,
+           activeSpeech.lane == .script
+            || activeSpeech.lane == .ambient
+            || activeSpeech.lane == .manual
+            || activeSpeech.interruptibility == .byUserAction {
+            replaceActiveSpeechIfNeeded()
         }
-        // Skip TTS when Silent, or when Mac is muted with no hardware duck
+
+        for (index, text) in cleaned.enumerated() {
+            let speech = ScheduledSpeech(
+                id: UUID(),
+                text: text,
+                lane: .script,
+                kind: .scriptStep,
+                scopeID: scriptID,
+                policy: index == 0 ? .exclusiveSession : .fifo,
+                interruptibility: interruptibility,
+                skipChirpWait: false,
+                onFinish: nil
+            )
+            scriptQueue.append(speech)
+        }
+        scheduleNextSpeechIfNeeded()
+    }
+
+    func stopSpeaking(reason: TTSStopReason = .userCancelled, clearQueues: Bool = true) {
+        simulatedSpeechTask?.cancel()
+        simulatedSpeechTask = nil
+        utteranceClearTimer?.cancel()
+        utteranceClearTimer = nil
+
+        if clearQueues {
+            clearNonCriticalQueuedSpeech()
+        }
+
+        if let backend = activePlaybackBackend {
+            backend.stopPlayback(reason: reason)
+        }
+
+        activeSpeech = nil
+        activePlaybackBackend = nil
+        isSpeaking = false
+        currentUtterance = ""
+        currentTurnScopeID = nil
+        exitConversation()
+    }
+
+    private func enqueueSpeech(_ speech: ScheduledSpeech) {
+        if speech.policy == .dropIfBusy,
+           activeSpeech != nil || !criticalQueue.isEmpty || !scriptQueue.isEmpty || pendingTurnSpeech != nil || pendingManualSpeech != nil {
+            return
+        }
+
+        if speech.lane != .ambient {
+            pendingAmbientSpeech = nil
+        }
+
+        switch speech.lane {
+        case .critical:
+            criticalQueue.append(speech)
+        case .script:
+            if speech.policy == .exclusiveSession {
+                scriptQueue.removeAll()
+            }
+            scriptQueue.append(speech)
+        case .turn:
+            pendingTurnSpeech = speech
+        case .manual:
+            pendingManualSpeech = speech
+        case .ambient:
+            pendingAmbientSpeech = speech
+        }
+
+        if shouldPreemptActiveSpeech(for: speech) {
+            replaceActiveSpeechIfNeeded()
+        }
+        scheduleNextSpeechIfNeeded()
+    }
+
+    private func shouldPreemptActiveSpeech(for incoming: ScheduledSpeech) -> Bool {
+        guard let activeSpeech else { return false }
+
+        switch incoming.lane {
+        case .critical:
+            return activeSpeech.lane != .critical
+        case .script:
+            return activeSpeech.lane == .ambient
+                || activeSpeech.lane == .manual
+                || activeSpeech.interruptibility == .byUserAction
+        case .turn:
+            if activeSpeech.lane == .turn, activeSpeech.scopeID == incoming.scopeID {
+                return true
+            }
+            return activeSpeech.lane == .ambient
+        case .manual:
+            if activeSpeech.lane == .manual || activeSpeech.lane == .ambient {
+                return true
+            }
+            return activeSpeech.interruptibility == .byUserAction
+        case .ambient:
+            return false
+        }
+    }
+
+    private func replaceActiveSpeechIfNeeded() {
+        guard activeSpeech != nil else { return }
+        simulatedSpeechTask?.cancel()
+        simulatedSpeechTask = nil
+        utteranceClearTimer?.cancel()
+        utteranceClearTimer = nil
+        activePlaybackBackend?.stopPlayback(reason: .replaced)
+        activeSpeech = nil
+        activePlaybackBackend = nil
+        isSpeaking = false
+    }
+
+    private func scheduleNextSpeechIfNeeded() {
+        guard activeSpeech == nil else { return }
+
+        let next: ScheduledSpeech?
+        if !criticalQueue.isEmpty {
+            next = criticalQueue.removeFirst()
+        } else if !scriptQueue.isEmpty {
+            next = scriptQueue.removeFirst()
+        } else if let pendingTurnSpeech {
+            next = pendingTurnSpeech
+            self.pendingTurnSpeech = nil
+        } else if let pendingManualSpeech {
+            next = pendingManualSpeech
+            self.pendingManualSpeech = nil
+        } else if let pendingAmbientSpeech {
+            next = pendingAmbientSpeech
+            self.pendingAmbientSpeech = nil
+        } else {
+            next = nil
+        }
+
+        guard let next else { return }
+        startSpeech(next)
+    }
+
+    private func startSpeech(_ speech: ScheduledSpeech) {
+        activeSpeech = speech
+        currentUtterance = speech.text
+        isSpeaking = true
+
         let systemMuted = audioPath == .local && AudioDeviceDiscovery.isSystemOutputMuted()
-        if !isSilent && !systemMuted {
-            // Reset to false first so onChange triggers even if we were already speaking
-            if isSpeaking { isSpeaking = false }
-            isSpeaking = true
-            activeTTS.speak(text, skipChirpWait: skipChirpWait)
-            // Poll gate.muted to detect when say finishes
-            speakingPollTimer?.cancel()
-            speakingPollTimer = Task {
-                while !Task.isCancelled {
-                    try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
-                    if !self.activeTTS.isMuted {
-                        await MainActor.run { self.isSpeaking = false }
-                        break
+        if isSilent || systemMuted {
+            let duration = estimatedSpeechDuration(for: speech.text)
+            simulatedSpeechTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+                if !Task.isCancelled {
+                    await MainActor.run {
+                        self.handleSpeechCompletion(for: speech.id, result: .finished)
                     }
                 }
             }
-        } else if isSilent || systemMuted {
-            // Mouth should still animate when showing speech bubble
-            isSpeaking = true
-            speakingPollTimer?.cancel()
-            speakingPollTimer = Task {
-                // Simulate speaking duration based on text length
-                let duration = 2.0 + Double(text.count) * 0.05
-                try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
-                if !Task.isCancelled {
-                    await MainActor.run { self.isSpeaking = false }
-                }
+            return
+        }
+
+        let playbackBackend = activeTTS
+        activePlaybackBackend = playbackBackend
+        playbackBackend.play(
+            speech.text,
+            utteranceID: speech.id,
+            skipChirpWait: speech.skipChirpWait
+        ) { [weak self] utteranceID, result in
+            self?.handleSpeechCompletion(for: utteranceID, result: result)
+        }
+    }
+
+    private func handleSpeechCompletion(for utteranceID: UUID, result: TTSPlaybackResult) {
+        guard activeSpeech?.id == utteranceID else { return }
+
+        simulatedSpeechTask?.cancel()
+        simulatedSpeechTask = nil
+        utteranceClearTimer?.cancel()
+        utteranceClearTimer = nil
+
+        let completion = activeSpeech?.onFinish
+        let finishedLane = activeSpeech?.lane
+        activeSpeech = nil
+        activePlaybackBackend = nil
+        isSpeaking = false
+        currentUtterance = ""
+        if finishedLane == .turn && pendingTurnSpeech == nil {
+            currentTurnScopeID = nil
+        }
+
+        if case .finished = result {
+            completion?()
+        }
+
+        scheduleNextSpeechIfNeeded()
+    }
+
+    private func estimatedSpeechDuration(for text: String) -> Double {
+        2.0 + Double(text.count) * 0.05
+    }
+
+    func makeListeningCompletionAction(enterConversation: Bool = false) -> (@MainActor () -> Void) {
+        { [weak self] in
+            guard let self else { return }
+            self.activeSTT.resetRestartAttempts()
+            self.startListening()
+            if enterConversation {
+                self.enterConversation()
             }
         }
     }
 
-    func stopSpeaking() {
-        activeTTS.stop()
-        speakingPollTimer?.cancel()
-        speakingPollTimer = nil
-        isSpeaking = false
-        utteranceClearTimer?.cancel()
-        currentUtterance = ""
-        exitConversation()
+    private func clearNonCriticalQueuedSpeech() {
+        scriptQueue.removeAll()
+        pendingTurnSpeech = nil
+        pendingManualSpeech = nil
+        pendingAmbientSpeech = nil
+        currentTurnScopeID = nil
     }
 
     /// Set master volume (0.0–1.0). Propagates to both TTS engines.
@@ -447,24 +730,24 @@ class SpeechService: ObservableObject {
     func askPermission(toolName: String, summary: String = "", options: [String] = []) {
         let label = summary.isEmpty ? toolName : summary
 
-        // One-sentence prompt: "Edit DuckView. Allow, always allow, or deny?"
+        // Use STT-friendly words: "yes/no/always" instead of "allow/deny"
+        // which Apple Speech frequently misrecognizes as "a lot", "aloud", etc.
         let shortPrompt: String
         let fullPrompt: String
 
         if options.count == 1 {
-            // Single option → "Allow, always allow, or deny?"
-            shortPrompt = "\(label). Allow, always allow, or deny?"
-            fullPrompt = "\(label). Allow, always allow to \(options[0]), or deny?"
+            shortPrompt = "\(label). Yes, always, or no?"
+            fullPrompt = "\(label). Yes, always to \(options[0]), or no?"
         } else if options.count == 2 {
-            shortPrompt = "\(label). Allow, always allow, or deny?"
-            fullPrompt = "\(label). Allow, always allow to \(options[0]), or say second to \(options[1]), or deny?"
+            shortPrompt = "\(label). Yes, always, or no?"
+            fullPrompt = "\(label). Yes, always to \(options[0]), or say second to \(options[1]), or no?"
         } else if options.count > 2 {
-            shortPrompt = "\(label). Allow or deny? Say repeat for options."
+            shortPrompt = "\(label). Yes or no? Say repeat for options."
             let numbered = options.enumerated().map { "\($0.offset + 1): \($0.element)" }.joined(separator: ". ")
-            fullPrompt = "\(label). Your options are: \(numbered). Or just allow or deny."
+            fullPrompt = "\(label). Your options are: \(numbered). Or just yes or no."
         } else {
             // No options
-            shortPrompt = "\(label). Allow or deny?"
+            shortPrompt = "\(label). Yes or no?"
             fullPrompt = shortPrompt
         }
 
@@ -474,8 +757,15 @@ class SpeechService: ObservableObject {
             prompt: shortPrompt,
             fullPrompt: fullPrompt
         )
-        speak(shortPrompt)
-        restartAfterTTS()  // Ensure STT is fresh after the prompt finishes
+        scheduleSpeech(
+            shortPrompt,
+            kind: .permission,
+            lane: .critical,
+            scopeID: "permission-active",
+            policy: .fifo,
+            interruptibility: .byCriticalOnly,
+            onFinish: makeListeningCompletionAction()
+        )
     }
 
     /// Clear the voice permission gate (permission resolved externally — CLI, timeout, etc.)
@@ -616,8 +906,15 @@ class SpeechService: ObservableObject {
                         await MainActor.run {
                             guard self.permissionGate.isWaiting else { return }
                             guard let decision = classified else {
-                                self.speak("Sorry, I didn't catch that. Say yes or no.")
-                                self.restartAfterTTS()
+                                self.scheduleSpeech(
+                                    "Didn't catch that. Yes or no?",
+                                    kind: .permission,
+                                    lane: .critical,
+                                    scopeID: "permission-active",
+                                    policy: .fifo,
+                                    interruptibility: .byCriticalOnly,
+                                    onFinish: self.makeListeningCompletionAction()
+                                )
                                 return
                             }
                             self.handlePermissionDecision(decision)
@@ -669,7 +966,15 @@ class SpeechService: ObservableObject {
             log("[speech] Wake word detected!")
 
             // Immediate acknowledgment — duck perks up (skip chirp for speed)
-            speak(["Yeah?", "Hmm?", "Yep?", "What's up?"].randomElement()!, skipChirpWait: true)
+            scheduleSpeech(
+                ["Yeah?", "Hmm?", "Yep?", "What's up?"].randomElement()!,
+                kind: .acknowledgement,
+                lane: .turn,
+                scopeID: "wake",
+                policy: .latestWins,
+                interruptibility: .freelyInterruptible,
+                skipChirpWait: true
+            )
 
             // Tell hardware to perk up (servo tilt)
             serialTransport?.sendCommand("W,1")
@@ -680,7 +985,14 @@ class SpeechService: ObservableObject {
                 try? await Task.sleep(nanoseconds: 5_000_000_000)
                 if !Task.isCancelled && self.wakeWordProcessor.isAwake && self.wakeWordProcessor.pendingText.isEmpty {
                     self.log("[speech] No command after wake word, restarting...")
-                    self.speak("Never mind.")
+                    self.scheduleSpeech(
+                        "Never mind.",
+                        kind: .acknowledgement,
+                        lane: .turn,
+                        scopeID: "wake",
+                        policy: .latestWins,
+                        interruptibility: .freelyInterruptible
+                    )
                     self.isWakeActive = false
                     self.hasAcknowledgedWake = false
                     self.serialTransport?.sendCommand("W,0")
@@ -718,8 +1030,15 @@ class SpeechService: ObservableObject {
             lastHeard = ""
             voiceInputTimer?.cancel()
             wakeWordProcessor.reset()
-            speak("Quack! See you later.")
-            restartAfterTTS()
+            scheduleSpeech(
+                "Quack! See you later.",
+                kind: .acknowledgement,
+                lane: .turn,
+                scopeID: "wake",
+                policy: .latestWins,
+                interruptibility: .freelyInterruptible,
+                onFinish: makeListeningCompletionAction()
+            )
         }
     }
 
@@ -727,25 +1046,61 @@ class SpeechService: ObservableObject {
     private func handlePermissionDecision(_ decision: PermissionVoiceGate.Decision) {
         switch decision {
         case .allow:
-            speak(["Got it.", "Done.", "Approved.", "Yep.", "Go for it."].randomElement()!)
+            scheduleSpeech(
+                ["Got it.", "Done.", "Approved.", "Yep.", "Go for it."].randomElement()!,
+                kind: .permission,
+                lane: .critical,
+                scopeID: "permission-active",
+                policy: .fifo,
+                interruptibility: .byCriticalOnly,
+                onFinish: makeListeningCompletionAction()
+            )
             onPermissionResponse?(0)
-            restartAfterTTS()
         case .deny:
-            speak(["Blocked it.", "Nope.", "Denied.", "Not happening."].randomElement()!)
+            scheduleSpeech(
+                ["Blocked it.", "Nope.", "Denied.", "Not happening."].randomElement()!,
+                kind: .permission,
+                lane: .critical,
+                scopeID: "permission-active",
+                policy: .fifo,
+                interruptibility: .byCriticalOnly,
+                onFinish: makeListeningCompletionAction()
+            )
             onPermissionResponse?(-1)
-            restartAfterTTS()
         case .selectOption(let index):
             if index > 0 && index <= permissionGate.optionLabels.count {
                 let label = permissionGate.optionLabels[index - 1]
-                speak("Got it. \(label.capitalized(with: nil)).")
+                scheduleSpeech(
+                    "Got it. \(label.capitalized(with: nil)).",
+                    kind: .permission,
+                    lane: .critical,
+                    scopeID: "permission-active",
+                    policy: .fifo,
+                    interruptibility: .byCriticalOnly,
+                    onFinish: makeListeningCompletionAction()
+                )
             } else {
-                speak(["Got it.", "Done."].randomElement()!)
+                scheduleSpeech(
+                    ["Got it.", "Done."].randomElement()!,
+                    kind: .permission,
+                    lane: .critical,
+                    scopeID: "permission-active",
+                    policy: .fifo,
+                    interruptibility: .byCriticalOnly,
+                    onFinish: makeListeningCompletionAction()
+                )
             }
             onPermissionResponse?(index)
-            restartAfterTTS()
         case .repeatPrompt:
-            speak(permissionGate.fullPrompt)
-            restartAfterTTS()
+            scheduleSpeech(
+                permissionGate.fullPrompt,
+                kind: .permission,
+                lane: .critical,
+                scopeID: "permission-active",
+                policy: .fifo,
+                interruptibility: .byCriticalOnly,
+                onFinish: makeListeningCompletionAction()
+            )
         case .noMatch:
             break  // Should not reach here
         }
@@ -763,7 +1118,16 @@ class SpeechService: ObservableObject {
         serialTransport?.sendCommand("W,0")
 
         log("[speech] Sending: \(text)")
-        speak(["On it.", "Sure thing.", "You got it.", "Working on it."].randomElement()!)
+        currentTurnScopeID = nextTurnScopeID()
+        scheduleSpeech(
+            ["On it.", "Sure thing.", "You got it.", "Working on it."].randomElement()!,
+            kind: .acknowledgement,
+            lane: .turn,
+            scopeID: currentTurnScopeID,
+            policy: .replaceScope,
+            interruptibility: .freelyInterruptible,
+            onFinish: makeListeningCompletionAction()
+        )
         onVoiceInput?(text)
 
         // Clear the displayed text after a beat so user sees it was sent
@@ -771,8 +1135,6 @@ class SpeechService: ObservableObject {
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             self.lastHeard = ""
         }
-
-        restartAfterTTS()
     }
 
     // MARK: - Conversation Mode
@@ -806,8 +1168,8 @@ class SpeechService: ObservableObject {
 
     func restartAfterTTS(thenEnterConversation: Bool = false) {
         Task {
-            // Wait for the active TTS engine to finish
-            while activeTTS.isMuted {
+            // Wait for the currently active speech request to drain.
+            while activeSpeech != nil {
                 try? await Task.sleep(nanoseconds: 200_000_000)
             }
             activeSTT.resetRestartAttempts()

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -119,6 +119,14 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         // --- Volume slider ---
         menu.addItem(volumeSliderItem())
 
+        // --- Subtitles toggle ---
+        let subtitleItem = NSMenuItem(title: "Show Subtitles", action: #selector(toggleSubtitles), keyEquivalent: "")
+        subtitleItem.target = self
+        subtitleItem.image = NSImage(systemSymbolName: "captions.bubble", accessibilityDescription: "Subtitles")
+        subtitleItem.subtitle = "Show speech bubbles with audio"
+        subtitleItem.state = DuckConfig.subtitlesEnabled ? .on : .off
+        menu.addItem(subtitleItem)
+
         // --- Mode submenu ---
         let currentMode = coordinator.mode
         let modeItem = NSMenuItem(title: currentMode.label, action: nil, keyEquivalent: "")
@@ -381,6 +389,10 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
     }
 
     // MARK: - Actions
+
+    @objc private func toggleSubtitles() {
+        DuckConfig.subtitlesEnabled.toggle()
+    }
 
     @objc private func startClaudeSession() {
         CLISession.launch()

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -14,6 +14,7 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
     private let coordinator: DuckCoordinator
     private let serialManager: SerialManager
     private let duckServer: DuckServer
+    var updateChecker: UpdateChecker?
 
     init(speechService: SpeechService, coordinator: DuckCoordinator,
          serialManager: SerialManager, duckServer: DuckServer) {
@@ -85,6 +86,35 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
 
     private func rebuildMenu(_ menu: NSMenu) {
         menu.removeAllItems()
+
+        // --- Update notifications (top of menu for visibility) ---
+        if let checker = updateChecker {
+            if checker.isUpdateAvailable, let release = checker.latestRelease {
+                let updateItem = NSMenuItem(
+                    title: "Update Available: v\(release.version)",
+                    action: #selector(openUpdatePage),
+                    keyEquivalent: ""
+                )
+                updateItem.target = self
+                updateItem.image = NSImage(systemSymbolName: "arrow.down.circle", accessibilityDescription: "Update")
+                updateItem.subtitle = "Download from GitHub"
+                menu.addItem(updateItem)
+            }
+            if checker.isPluginStale {
+                let pluginItem = NSMenuItem(
+                    title: "Plugin Update Available",
+                    action: #selector(updatePlugin),
+                    keyEquivalent: ""
+                )
+                pluginItem.target = self
+                pluginItem.image = NSImage(systemSymbolName: "puzzlepiece.extension.fill", accessibilityDescription: "Plugin")
+                pluginItem.subtitle = "Reinstall to get latest hooks"
+                menu.addItem(pluginItem)
+            }
+            if checker.isUpdateAvailable || checker.isPluginStale {
+                menu.addItem(.separator())
+            }
+        }
 
         // --- Volume slider ---
         menu.addItem(volumeSliderItem())
@@ -354,6 +384,18 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
 
     @objc private func startClaudeSession() {
         CLISession.launch()
+    }
+
+    @objc private func openUpdatePage() {
+        guard let release = updateChecker?.latestRelease else { return }
+        let urlString = release.dmgURL ?? release.htmlURL
+        if let url = URL(string: urlString) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    @objc private func updatePlugin() {
+        PluginInstaller.install()
     }
 
     @objc private func installClaudeCLI() {
@@ -972,6 +1014,9 @@ enum PluginInstaller {
 
     @MainActor
     private static func showResult(success: Bool, detail: String) {
+        if success {
+            UpdateChecker.recordPluginInstalled()
+        }
         showInstallResult(title: "Plugin Installed", success: success, detail: detail)
     }
 }

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -433,20 +433,43 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         speechService.ttsVoice = DuckVoices.wildcardSayName
         // Preview in Superstar (the default wildcard voice)
         speechService.setVoiceTransient(DuckVoices.wildcardDefault.sayName)
-        speechService.speak("Wildcard mode.", skipChirpWait: true)
+        speechService.scheduleSpeech(
+            "Wildcard mode.",
+            kind: .preview,
+            lane: .manual,
+            scopeID: "voice-preview",
+            policy: .latestWins,
+            interruptibility: .freelyInterruptible,
+            skipChirpWait: true
+        )
     }
 
     @objc private func selectSilent() {
         speechService.ttsVoice = DuckVoices.silentSayName
         // This triggers the speech bubble since isSilent is now true
-        speechService.speak("Silent mode. I'll use speech bubbles instead.")
+        speechService.scheduleSpeech(
+            "Silent mode. I'll use speech bubbles instead.",
+            kind: .preview,
+            lane: .manual,
+            scopeID: "voice-preview",
+            policy: .latestWins,
+            interruptibility: .freelyInterruptible
+        )
     }
 
     @objc private func selectVoice(_ sender: NSMenuItem) {
         guard let sayName = sender.representedObject as? String else { return }
         speechService.ttsVoice = sayName
         let voice = DuckVoices.all.first { $0.sayName == sayName }
-        speechService.speak(voice?.preview ?? "This is how I sound.", skipChirpWait: true)
+        speechService.scheduleSpeech(
+            voice?.preview ?? "This is how I sound.",
+            kind: .preview,
+            lane: .manual,
+            scopeID: "voice-preview",
+            policy: .latestWins,
+            interruptibility: .freelyInterruptible,
+            skipChirpWait: true
+        )
     }
 
     @objc private func setLaunchAtLogin() {

--- a/widget/Sources/RubberDuckWidget/TTSEngine.swift
+++ b/widget/Sources/RubberDuckWidget/TTSEngine.swift
@@ -29,6 +29,13 @@ class TTSGate: @unchecked Sendable {
 
 @MainActor
 class TTSEngine {
+    private struct PlaybackSession {
+        let id: UUID
+        let completion: TTSPlaybackCompletion
+        var processes: [Process]
+        var stopReason: TTSStopReason?
+    }
+
     /// Shared gate for muting mic input during TTS playback.
     let gate = TTSGate()
 
@@ -45,7 +52,8 @@ class TTSEngine {
         didSet { applyDeviceVolume() }
     }
 
-    private var ttsProcess: Process?
+    private var activeSessionID: UUID?
+    private var sessions: [UUID: PlaybackSession] = [:]
     private func log(_ msg: String) { DuckLog.log(msg) }
 
     /// Speak text through the configured output device.
@@ -83,89 +91,121 @@ class TTSEngine {
         return result
     }
 
-    func speak(_ text: String) {
+    func play(_ text: String, utteranceID: UUID, skipChirpWait: Bool = false, completion: @escaping TTSPlaybackCompletion) {
         guard !text.isEmpty else { return }
         log("[tts] \(text)")
 
-        // Stop any current speech to prevent pileup
-        stop()
-
         let cleaned = applyPronunciations(stripMarkdown(text))
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/say")
+        let primary = Process()
+        primary.executableURL = URL(fileURLWithPath: "/usr/bin/say")
 
         // Route to Teensy speaker via `-a <name>` if available.
         // Note: `say -a` uses its OWN device IDs (not CoreAudio AudioDeviceID),
         // but it also accepts device names — use the name for reliability.
         if let name = outputDeviceName {
-            task.arguments = ["-v", voice, "-a", name, cleaned]
+            primary.arguments = ["-v", voice, "-a", name, cleaned]
         } else {
-            task.arguments = ["-v", voice, cleaned]
+            primary.arguments = ["-v", voice, cleaned]
         }
 
-        task.standardOutput = FileHandle.nullDevice
-        task.standardError = FileHandle.nullDevice
+        primary.standardOutput = FileHandle.nullDevice
+        primary.standardError = FileHandle.nullDevice
 
         // Mute mic input while speaking to prevent feedback
         // (speaker is right next to electret mic on the duck)
         gate.muted = true
-        ttsProcess = task
+        activeSessionID = utteranceID
+        sessions[utteranceID] = PlaybackSession(
+            id: utteranceID,
+            completion: completion,
+            processes: [primary],
+            stopReason: nil
+        )
 
-        let g = gate
         let voiceName = voice              // capture for Sendable closure
         let deviceName = outputDeviceName  // capture for retry
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        let originalText = text
+        Task.detached(priority: .userInitiated) { [weak self] in
+            guard let self else { return }
             do {
-                try task.run()
-                task.waitUntilExit()
-
-                // If stop() killed this process (SIGTERM), a new speak() has
-                // already taken over — exit silently without retrying or
-                // touching the gate/device state.
-                if task.terminationReason == .uncaughtSignal {
-                    DuckLog.log("[tts] say was cancelled (superseded)")
+                if await self.stopReason(for: utteranceID) != nil {
+                    await self.finishSession(utteranceID, defaultResult: .cancelled(.replaced))
                     return
                 }
 
+                try primary.run()
+                primary.waitUntilExit()
+
                 // If say -a failed (device gone, not killed), retry on system default
-                if task.terminationStatus != 0, deviceName != nil {
-                    DuckLog.log("[tts] say -a failed (exit \(task.terminationStatus)) — retrying on system audio")
-                    Task { @MainActor in
-                        self?.outputDeviceName = nil
+                if primary.terminationStatus != 0,
+                   primary.terminationReason != .uncaughtSignal,
+                   deviceName != nil,
+                   await self.stopReason(for: utteranceID) == nil {
+                    DuckLog.log("[tts] say -a failed (exit \(primary.terminationStatus)) — retrying on system audio")
+                    await MainActor.run {
+                        self.outputDeviceName = nil
                     }
                     let retry = Process()
                     retry.executableURL = URL(fileURLWithPath: "/usr/bin/say")
-                    retry.arguments = ["-v", voiceName, text]
+                    retry.arguments = ["-v", voiceName, originalText]
                     retry.standardOutput = FileHandle.nullDevice
                     retry.standardError = FileHandle.nullDevice
+                    await self.registerProcess(retry, for: utteranceID)
+                    if await self.stopReason(for: utteranceID) != nil {
+                        await self.finishSession(utteranceID, defaultResult: .cancelled(.replaced))
+                        return
+                    }
                     try retry.run()
                     retry.waitUntilExit()
                 }
             } catch {
                 DuckLog.log("[tts] say failed: \(error)")
+                await self.finishSession(utteranceID, defaultResult: .failed)
+                return
             }
-            // Unmute after say exits + brief delay for USB audio buffer drain
-            Thread.sleep(forTimeInterval: 0.3)
-            g.muted = false
-            Task { @MainActor in
-                if self?.ttsProcess === task {
-                    self?.ttsProcess = nil
-                }
+
+            if let stopReason = await self.stopReason(for: utteranceID) {
+                DuckLog.log("[tts] say was cancelled (superseded)")
+                await self.finishSession(utteranceID, defaultResult: .cancelled(stopReason))
+                return
             }
+
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            await self.finishSession(utteranceID, defaultResult: .finished)
         }
     }
 
-    /// Stop any currently speaking process.
-    func stop() {
-        if let process = ttsProcess, process.isRunning {
+    func stopPlayback(reason: TTSStopReason) {
+        guard let activeSessionID, var session = sessions[activeSessionID] else { return }
+        session.stopReason = reason
+        sessions[activeSessionID] = session
+        for process in session.processes where process.isRunning {
             process.terminate()
-            ttsProcess = nil
         }
-        gate.muted = false
     }
 
     /// Whether TTS is currently muting the mic.
     var isMuted: Bool { gate.muted }
+
+    private func stopReason(for sessionID: UUID) -> TTSStopReason? {
+        sessions[sessionID]?.stopReason
+    }
+
+    private func registerProcess(_ process: Process, for sessionID: UUID) {
+        guard var session = sessions[sessionID] else { return }
+        session.processes.append(process)
+        sessions[sessionID] = session
+    }
+
+    private func finishSession(_ sessionID: UUID, defaultResult: TTSPlaybackResult) {
+        guard let session = sessions.removeValue(forKey: sessionID) else { return }
+        let result = session.stopReason.map(TTSPlaybackResult.cancelled) ?? defaultResult
+        if activeSessionID == sessionID {
+            activeSessionID = nil
+            gate.muted = false
+        }
+        session.completion(sessionID, result)
+    }
 
     // MARK: - CoreAudio Device Volume
 

--- a/widget/Sources/RubberDuckWidget/UpdateChecker.swift
+++ b/widget/Sources/RubberDuckWidget/UpdateChecker.swift
@@ -1,0 +1,205 @@
+// Update Checker — Polls GitHub Releases API to detect new app versions.
+//
+// Zero dependencies. Uses URLSession.shared (same as eval APIs).
+// Checks on launch (30s delay) then every 12 hours while running.
+// Publishes results via callbacks — menus and TTS wire in at startup.
+
+import Foundation
+
+@MainActor
+final class UpdateChecker {
+    private static let releasesURL = "https://api.github.com/repos/ideo/Rubber-Duck/releases/latest"
+    private static let checkInterval: TimeInterval = 12 * 60 * 60  // 12 hours
+    private static let initialDelay: TimeInterval = 30
+
+    struct ReleaseInfo {
+        let version: String       // e.g. "0.8.5"
+        let tagName: String       // e.g. "v0.8.5"
+        let htmlURL: String       // releases page
+        let dmgURL: String?       // direct DMG download from assets
+        let releaseNotes: String  // body text
+    }
+
+    // Published state — read by menus
+    private(set) var latestRelease: ReleaseInfo?
+    private(set) var isUpdateAvailable = false
+    private(set) var isPluginStale = false
+
+    // Callbacks wired by the app at startup
+    var onUpdateDetected: ((ReleaseInfo) -> Void)?
+    var onPluginStale: (() -> Void)?
+
+    private var hasSpokeThisLaunch = false
+    private var timer: Timer?
+
+    // MARK: - Lifecycle
+
+    func startPeriodicChecks() {
+        // Initial check after a delay so we don't compete with mic/server/TTS startup
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.initialDelay) { [weak self] in
+            Task { await self?.checkForUpdate() }
+            self?.scheduleTimer()
+        }
+    }
+
+    func stopPeriodicChecks() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func scheduleTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: Self.checkInterval, repeats: true) { [weak self] _ in
+            Task { await self?.checkForUpdate() }
+        }
+    }
+
+    // MARK: - App Version Change Detection
+
+    /// Call on launch to detect if the app was just updated.
+    /// Returns true if the running version differs from the last-run version.
+    func detectAppVersionChange() -> Bool {
+        let current = Self.runningVersion
+        let last = DuckConfig.lastRunAppVersion
+        DuckConfig.lastRunAppVersion = current
+        guard let last, last != current else { return false }
+        DuckLog.log("[update] App version changed: \(last) → \(current)")
+        return true
+    }
+
+    /// Check if the bundled plugin is newer than what was last installed.
+    func detectPluginStaleness() {
+        let bundled = Self.bundledPluginVersion
+        let installed = DuckConfig.lastInstalledPluginVersion
+        if let installed, bundled > installed {
+            DuckLog.log("[update] Plugin stale: installed=\(installed) bundled=\(bundled)")
+            isPluginStale = true
+            onPluginStale?()
+        }
+    }
+
+    /// Mark the current bundled plugin version as installed.
+    static func recordPluginInstalled() {
+        DuckConfig.lastInstalledPluginVersion = bundledPluginVersion
+        DuckLog.log("[update] Recorded installed plugin version: \(bundledPluginVersion)")
+    }
+
+    /// Check if a remotely-reported plugin version is stale vs the bundled version.
+    func checkRemotePluginVersion(_ reportedVersion: Int) {
+        let bundled = Self.bundledPluginVersion
+        if reportedVersion < bundled {
+            DuckLog.log("[update] Remote plugin stale: reported=\(reportedVersion) bundled=\(bundled)")
+            isPluginStale = true
+            onPluginStale?()
+        } else {
+            isPluginStale = false
+        }
+    }
+
+    // MARK: - GitHub API
+
+    func checkForUpdate() async {
+        // Rate limit: skip if checked recently
+        if let last = DuckConfig.lastUpdateCheckTimestamp,
+           Date().timeIntervalSince1970 - last < Self.checkInterval - 60 {
+            return
+        }
+
+        DuckLog.log("[update] Checking GitHub for new release...")
+        DuckConfig.lastUpdateCheckTimestamp = Date().timeIntervalSince1970
+
+        guard let url = URL(string: Self.releasesURL) else { return }
+
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("DuckDuckDuck/\(Self.runningVersion)", forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                DuckLog.log("[update] GitHub API returned non-200")
+                return
+            }
+
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                DuckLog.log("[update] Failed to parse GitHub response")
+                return
+            }
+
+            guard let tagName = json["tag_name"] as? String else { return }
+            let htmlURL = json["html_url"] as? String ?? "https://github.com/ideo/Rubber-Duck/releases"
+            let body = json["body"] as? String ?? ""
+
+            // Find DMG asset
+            let assets = json["assets"] as? [[String: Any]] ?? []
+            let dmgURL = assets.first(where: {
+                ($0["name"] as? String ?? "").hasSuffix(".dmg")
+            })?["browser_download_url"] as? String
+
+            let version = tagName.hasPrefix("v") ? String(tagName.dropFirst()) : tagName
+            let release = ReleaseInfo(
+                version: version,
+                tagName: tagName,
+                htmlURL: htmlURL,
+                dmgURL: dmgURL,
+                releaseNotes: body
+            )
+
+            let running = Self.parseVersion(Self.runningVersion)
+            let latest = Self.parseVersion(version)
+
+            if Self.compareVersions(latest, running) == .orderedDescending {
+                DuckLog.log("[update] New version available: \(version) (running \(Self.runningVersion))")
+                latestRelease = release
+                isUpdateAvailable = true
+
+                if !hasSpokeThisLaunch {
+                    hasSpokeThisLaunch = true
+                    onUpdateDetected?(release)
+                }
+            } else {
+                DuckLog.log("[update] Up to date (\(Self.runningVersion))")
+                isUpdateAvailable = false
+                latestRelease = nil
+            }
+        } catch {
+            DuckLog.log("[update] GitHub check failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Version Utilities
+
+    static var runningVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    static var bundledPluginVersion: Int {
+        guard let pluginDir = Bundle.main.resourceURL?.appendingPathComponent("plugin"),
+              let data = try? Data(contentsOf: pluginDir
+                  .appendingPathComponent(".claude-plugin")
+                  .appendingPathComponent("plugin.json")),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let vStr = json["version"] as? String,
+              let v = Int(vStr) else {
+            return 0
+        }
+        return v
+    }
+
+    static func parseVersion(_ string: String) -> [Int] {
+        string.components(separatedBy: ".").compactMap { Int($0) }
+    }
+
+    static func compareVersions(_ a: [Int], _ b: [Int]) -> ComparisonResult {
+        let maxLen = max(a.count, b.count)
+        for i in 0..<maxLen {
+            let va = i < a.count ? a[i] : 0
+            let vb = i < b.count ? b[i] : 0
+            if va > vb { return .orderedDescending }
+            if va < vb { return .orderedAscending }
+        }
+        return .orderedSame
+    }
+}


### PR DESCRIPTION
## PR Summary

### Voice Permission System Overhaul

Rewrites how the duck handles Claude Code permission requests — fixing reliability issues, reducing noise, and adding intelligence about when to ask.

### Changes

**Permission voice prompts — STT-friendly wording** (`SpeechService.swift`, `PermissionVoiceGate.swift`)
- Voice prompts now say "Yes, always, or no?" instead of "Allow, always allow, or deny?" — Apple Speech frequently misrecognizes "allow" as "a lot"/"aloud"
- Added common STT misrecognitions ("aloud", "allowed") to the affirmatives word set as a fallback

**"Always allow" fix** (`PermissionVoiceGate.swift`, `plugin/hooks/on-permission-request.sh`, `scripts/on-permission-request.sh`)
- Voice gate now picks the last matching "always allow" suggestion instead of the first — Claude Code puts the tool-level rule (the useful one) last, and narrower read-path rules first
- `updatedPermissions` in hook output is now wrapped as an array, matching the format Claude Code expects

**Permission request queuing** (`PermissionGate.swift`, `DuckServer.swift`)
- Replaced single-slot `CheckedContinuation` with a FIFO queue — concurrent requests from multiple sessions now block independently instead of clobbering each other
- Each request gets its own 30s timeout
- When the head resolves, the next queued request automatically becomes active via `onBecameActive` callback

**No more phantom auto-approvals** (`DuckServer.swift`, `DuckCoordinator.swift`)
- `/permission-clear` (PostToolUse hook) no longer calls `resolve()` — it was draining queued requests as "allow" without user consent
- Removed `handleNewEval()` auto-clear of `permissionPending` — evals from session A were wiping permission state for session B

**Smart permission filtering** (`plugin/hooks/on-permission-request.sh`)
- Zero suggestions + not AskUserQuestion/ExitPlanMode → silent pass-through
- Plan mode (except AskUserQuestion/ExitPlanMode) → silent pass-through
- All `mcp__*` tools → silent pass-through (subagent actions the user never sees)
- No filtered path outputs `"allow"` — all pass through to Claude Code's own permission system

**AskUserQuestion voice readout** (`DuckServer.swift`)
- Duck reads the question text and numbered options aloud as a heads-up
- Returns empty response (pass-through) — the actual answer goes through Claude Code's UI

**Better MCP tool summaries** (`DuckServer.swift`)
- `mcp__Claude_Preview__preview_eval` now says "preview eval" instead of "Use a connector"

**Tap-to-pause → right-click context menu** (`DuckView.swift`)
- Removed unreliable tap gesture (wings flash and disappear, no feedback)
- Added Pause/Resume button to the context menu with play/pause icons

**Speech scheduling system** (`SpeechService.swift`, `DuckCoordinator.swift`)
- New lane-based speech queue (critical > script > turn > manual > ambient) replacing the old fire-and-forget `speak()` method
- Policies: FIFO, latestWins, replaceScope, dropIfBusy
- Interruptibility levels so permissions can't be interrupted by reactions

**Audio backend refactor** (`TTSEngine.swift`, `SerialTTSEngine.swift`, `AudioBackend.swift`)
- `TTSBackend` protocol for pluggable audio output (local `say` command vs serial)
- Session-based playback with per-utterance tracking and stop reasons

**Update checker** (`UpdateChecker.swift`, `StatusBarManager.swift`, `DuckView.swift`)
- Checks GitHub releases for app updates
- Plugin version staleness detection via `/plugin-check` endpoint
- "Update Available" and "Plugin Update Available" buttons in the right-click context menu

**Preferences** (`PreferencesView.swift`)
- Subtitles toggle for speech bubble visibility
- Additional preference controls

**Documentation** (`docs/`)
- Speech orchestration design doc
- Help manual recommendations
- Updated help grounding doc