### PR TITLE
Widget firmware updater (phase 1): detect duck staleness, hand off to web flasher

### DIFF
--- a/.github/workflows/cc-firmware-release.yml
+++ b/.github/workflows/cc-firmware-release.yml
@@ -72,15 +72,25 @@ jobs:
         run: pip install esptool
 
       - name: Stamp firmware version into build_opt.h
-        # The tag name (cc-v0.1.4 / "manual" for workflow_dispatch) goes
-        # into the USB serial-number descriptor so the web flasher can
-        # read it back via WebUSB and tell the user which build is on
-        # their duck — and whether it's behind latest. No spaces in tag
-        # names, so safe to append as a -D flag without the quoting
-        # problems that bit USB_PRODUCT.
+        # The tag name (cc-v0.1.4 / "manual" for workflow_dispatch) is
+        # stamped into TWO places via build_opt.h flags:
+        #
+        #   USB_SERIAL      — read by the web flasher via WebUSB so it
+        #                     can show "Claude Code Duck (cc-v0.1.4)"
+        #                     on the page when a duck is plugged in.
+        #   FIRMWARE_VERSION — emitted in the chip's DUCK identity reply
+        #                     over the existing widget-serial protocol,
+        #                     so the desktop widget's FirmwareUpdater
+        #                     can compare to docs/flash/firmware/
+        #                     cc-latest.json and surface "Duck firmware
+        #                     update available" in the menu.
+        #
+        # No spaces in tag names so neither needs the bash-quoting
+        # gymnastics that USB_PRODUCT (which has spaces) avoids.
         run: |
           VERSION="${{ github.ref_name }}"
           echo "-DUSB_SERIAL=\\\"$VERSION\\\"" >> ${{ matrix.sketch_dir }}/build_opt.h
+          echo "-DFIRMWARE_VERSION=\\\"$VERSION\\\"" >> ${{ matrix.sketch_dir }}/build_opt.h
           echo "build_opt.h after stamping:"
           cat ${{ matrix.sketch_dir }}/build_opt.h
 

--- a/firmware/rubber_duck_s3/SerialProtocol.ino
+++ b/firmware/rubber_duck_s3/SerialProtocol.ino
@@ -147,14 +147,23 @@ void parseTextMessage(char *msg) {
   }
 
   // --- Identity (handshake) ---
+  // Format: DUCK,<chip>,<protocol_ver>,<variant>[,<firmware_ver>]
+  // FIRMWARE_VERSION only appears when -DFIRMWARE_VERSION="..." was
+  // passed at compile time (CI does this from the git tag). See the
+  // parallel block in rubber_duck_s3_ducky/SerialProtocol.ino.
   if (source == 'I') {
     #if defined(CONFIG_IDF_TARGET_ESP32S3)
-      Serial.println("DUCK,ESP32S3,1.0,XIAO");
+      Serial.print("DUCK,ESP32S3,1.0,XIAO");
     #elif defined(CONFIG_IDF_TARGET_ESP32C3)
-      Serial.println("DUCK,ESP32C3,1.0,XIAO");
+      Serial.print("DUCK,ESP32C3,1.0,XIAO");
     #else
-      Serial.println("DUCK,ESP32,1.0,XIAO");
+      Serial.print("DUCK,ESP32,1.0,XIAO");
     #endif
+#ifdef FIRMWARE_VERSION
+    Serial.print(",");
+    Serial.print(FIRMWARE_VERSION);
+#endif
+    Serial.println();
     // Play "Connected" on first handshake (or reconnect)
     if (!widgetConnected) {
       widgetConnected = true;

--- a/firmware/rubber_duck_s3_ducky/SerialProtocol.ino
+++ b/firmware/rubber_duck_s3_ducky/SerialProtocol.ino
@@ -137,8 +137,21 @@ void parseTextMessage(char *msg) {
   }
 
   // --- Identity (handshake) ---
+  // Format: DUCK,<chip>,<protocol_ver>,<variant>[,<firmware_ver>]
+  // The 5th field (firmware version) only appears when the sketch was
+  // compiled with -DFIRMWARE_VERSION="..." — CI does this from the git
+  // tag (e.g. "cc-v0.1.4"). Local dev builds without the flag still
+  // reply with the legacy 4-field form, which the widget treats as
+  // "version unknown" (no update prompt). Comma-prefixed so the widget
+  // can find it as the 5th split index without confusing older builds
+  // that send only 4 fields.
   if (source == 'I') {
-    Serial.println("DUCK,ESP32S3,1.0,DUCKY_PCB");
+    Serial.print("DUCK,ESP32S3,1.0,DUCKY_PCB");
+#ifdef FIRMWARE_VERSION
+    Serial.print(",");
+    Serial.print(FIRMWARE_VERSION);
+#endif
+    Serial.println();
     if (!widgetConnected) {
       widgetConnected = true;
       deferredConnected = true;

--- a/widget/Sources/RubberDuckWidget/FirmwareUpdater.swift
+++ b/widget/Sources/RubberDuckWidget/FirmwareUpdater.swift
@@ -1,0 +1,209 @@
+// Firmware Updater — Detects when the plugged-in duck is running older
+// firmware than what's published on Pages and surfaces a status-bar
+// menu item to (currently) hand off to the web flasher. A future
+// phase will bundle espflash to do the reflash in-app; today it just
+// notices and points the user at https://ideo.github.io/Rubber-Duck/flash/.
+//
+// Why a separate service from UpdateChecker:
+//   - UpdateChecker watches the WIDGET app (Mac binary) against GitHub
+//     Releases; the user clicks → downloads a .dmg.
+//   - FirmwareUpdater watches the DUCK (the ESP32 plugged into USB)
+//     against docs/flash/firmware/cc-latest.json on Pages; the user
+//     clicks → opens the web flasher.
+// Different lifecycles (firmware bumps don't ship .dmg releases anymore
+// and vice versa), different staleness signals (USB-serial handshake
+// vs. running CFBundleShortVersionString), and the web-flasher hand-off
+// is firmware-specific. Mixing them into UpdateChecker would tangle the
+// menu logic and re-introduce the GitHub Releases coupling we just
+// stripped out.
+//
+// Data flow:
+//   1. SerialTransport.parseIdentity now captures the firmware version
+//      from the DUCK,<chip>,<proto>,<variant>,<firmware_ver> handshake.
+//   2. SerialTransport.onIdentity fires whenever a duck completes a
+//      fresh handshake (boot or replug).
+//   3. We re-check then; also periodic poll every 12h via timer (same
+//      cadence as UpdateChecker so we're not chatty about it).
+//   4. cc-latest.json fetched from Pages; small JSON, cached briefly.
+//   5. Version compare (string equality is fine — tags are exact).
+//   6. Publish isFirmwareUpdateAvailable; StatusBarManager reads it.
+
+import Foundation
+
+@MainActor
+final class FirmwareUpdater {
+    // Per-variant manifest URL on the Pages site. Bambu firmware will
+    // get its own checker if/when we add an in-widget OTA story for it
+    // (currently Bambu OTA happens on-device via the captive portal —
+    // the widget never talks to a Bambu duck). For Claude Code Duck
+    // there's one manifest covering both ducky PCB and XIAO variants.
+    private static let manifestURL =
+        "https://ideo.github.io/Rubber-Duck/flash/firmware/cc-latest.json"
+
+    /// User-facing landing page for the flash hand-off. Phase 2 will
+    /// replace clicking-here-opens-browser with an in-app sheet that
+    /// drives espflash directly, but the URL stays valid as the
+    /// "advanced / recovery" path.
+    static let webFlasherURL = "https://ideo.github.io/Rubber-Duck/flash/"
+
+    private static let checkInterval: TimeInterval = 12 * 60 * 60  // 12 hours
+    private static let initialDelay: TimeInterval = 35  // after UpdateChecker's 30s
+
+    struct LatestManifest {
+        let version: String   // e.g. "cc-v0.1.4"
+        let releasedAt: String
+
+        /// Map from variant tag (matches SerialTransport.connectedVariant,
+        /// e.g. "DUCKY_PCB" or "XIAO") to the same-origin download URL
+        /// for that variant's .bin. Used by the phase-2 in-app flasher;
+        /// phase 1 doesn't read it.
+        let binaryURLByVariant: [String: String]
+    }
+
+    // Published state — read by StatusBarManager.
+    private(set) var latestManifest: LatestManifest?
+    private(set) var connectedFirmwareVersion: String?
+    private(set) var isFirmwareUpdateAvailable = false
+
+    // Callbacks wired at startup. onFirmwareStale fires once per fresh
+    // detection so SpeechService can react if we ever want the duck to
+    // mention it (we don't right now — quiet by design).
+    var onFirmwareStale: ((LatestManifest, _ runningVersion: String) -> Void)?
+
+    private var timer: Timer?
+    private weak var serialTransport: SerialTransport?
+
+    // MARK: - Lifecycle
+
+    /// Plumb in the serial transport so we can read the duck's reported
+    /// firmware version. Optional: if no duck is ever plugged in, we
+    /// still poll the manifest but won't compare against anything.
+    func bind(to transport: SerialTransport) {
+        self.serialTransport = transport
+        // Re-check whenever a duck completes a handshake. Replug, boot,
+        // reflash via the web flasher — all trigger a fresh identity.
+        transport.onIdentity = { [weak self] in
+            Task { @MainActor in
+                self?.handleNewIdentity()
+            }
+        }
+    }
+
+    func startPeriodicChecks() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.initialDelay) { [weak self] in
+            Task { await self?.refreshManifest() }
+            self?.scheduleTimer()
+        }
+    }
+
+    func stopPeriodicChecks() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func scheduleTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: Self.checkInterval, repeats: true) { [weak self] _ in
+            Task { await self?.refreshManifest() }
+        }
+    }
+
+    // MARK: - Manifest fetch
+
+    /// Force a re-check. Called when the Preferences pane appears so
+    /// users staring at the firmware row see fresh data, not a stale
+    /// 12-hour-old hit.
+    func forceCheck() async {
+        await refreshManifest()
+    }
+
+    private func refreshManifest() async {
+        guard let url = URL(string: Self.manifestURL) else { return }
+        var request = URLRequest(url: url)
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("DuckDuckDuck/\(UpdateChecker.runningVersion)",
+                         forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                DuckLog.log("[firmware-updater] manifest fetch non-200")
+                return
+            }
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let version = json["version"] as? String else {
+                DuckLog.log("[firmware-updater] manifest parse failed")
+                return
+            }
+            let releasedAt = json["released_at"] as? String ?? ""
+            var byVariant: [String: String] = [:]
+            if let variants = json["variants"] as? [String: Any] {
+                for (key, value) in variants {
+                    if let entry = value as? [String: Any],
+                       let url = entry["url"] as? String {
+                        // Manifest key is lowercase ("ducky" / "xiao");
+                        // the chip's identity reply uses uppercase tags
+                        // ("DUCKY_PCB" / "XIAO"). Store both lookups so
+                        // either side can fetch without casing rules.
+                        byVariant[key.uppercased()] = url
+                        byVariant[key] = url
+                    }
+                }
+            }
+            // The manifest's "ducky" key needs a DUCKY_PCB alias since
+            // that's what the chip reports — lowercase->uppercase above
+            // gives us "DUCKY" but not "DUCKY_PCB". Add it explicitly.
+            if let duckyURL = byVariant["ducky"] {
+                byVariant["DUCKY_PCB"] = duckyURL
+            }
+            let manifest = LatestManifest(
+                version: version,
+                releasedAt: releasedAt,
+                binaryURLByVariant: byVariant
+            )
+            self.latestManifest = manifest
+            DuckLog.log("[firmware-updater] manifest latest=\(version)")
+            recomputeStaleness()
+        } catch {
+            DuckLog.log("[firmware-updater] manifest fetch error: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Staleness compute
+
+    private func handleNewIdentity() {
+        connectedFirmwareVersion = serialTransport?.connectedFirmwareVersion
+        recomputeStaleness()
+    }
+
+    private func recomputeStaleness() {
+        guard let manifest = latestManifest else {
+            // No manifest yet — don't claim stale or fresh, just wait.
+            isFirmwareUpdateAvailable = false
+            return
+        }
+        guard let running = connectedFirmwareVersion ?? serialTransport?.connectedFirmwareVersion else {
+            // No firmware version reported — could be old firmware that
+            // pre-dates the FIRMWARE_VERSION stamp, or no duck plugged
+            // in. Either way, can't compare → don't surface a prompt.
+            // We don't want every unflashed/legacy duck to nag.
+            isFirmwareUpdateAvailable = false
+            return
+        }
+        connectedFirmwareVersion = running
+        // Exact string compare. Tags are immutable and version-ordered
+        // already (cc-v0.1.3 < cc-v0.1.4 alphabetically), but the more
+        // important property here is "matches latest" vs "doesn't" —
+        // we're not trying to gate on monotonicity. If a user is
+        // running a pre-release built ad-hoc from a non-tag commit,
+        // they'll see "update available" against the latest tag, which
+        // is correct: they probably do want to know.
+        let stale = running != manifest.version
+        if stale && !isFirmwareUpdateAvailable {
+            DuckLog.log("[firmware-updater] stale: running=\(running) latest=\(manifest.version)")
+            onFirmwareStale?(manifest, running)
+        }
+        isFirmwareUpdateAvailable = stale
+    }
+}

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -441,6 +441,19 @@ struct RubberDuckWidgetApp: App {
 
         updateChecker.startPeriodicChecks()
 
+        // Firmware updater — separate cadence and signal from the app
+        // updater. Watches the plugged-in duck's reported firmware
+        // version (from the DUCK,...,<firmware_ver> handshake) against
+        // docs/flash/firmware/cc-latest.json on Pages. Surfaces in the
+        // status menu if the duck is behind; hands off to the web
+        // flasher on click. Quiet by design — no TTS callback wired
+        // because firmware drift isn't urgent enough to interrupt.
+        let firmwareUpdater = FirmwareUpdater()
+        firmwareUpdater.bind(to: serial.serialTransport)
+        statusBarManager?.firmwareUpdater = firmwareUpdater
+        AppDelegate.firmwareUpdater = firmwareUpdater
+        firmwareUpdater.startPeriodicChecks()
+
         // Wire lifecycle hooks from DuckServer → coordinator
         let transport = server.localTransport
         transport.onSpeak = { [weak speech] text in
@@ -545,6 +558,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     static var openWindow: ((String) -> Void)?
     /// Update checker — accessible from About pane for force-check on appear.
     static var updateChecker: UpdateChecker?
+    /// Firmware updater — accessible from About pane (or future
+    /// firmware-row in Settings) for force-check on appear.
+    static var firmwareUpdater: FirmwareUpdater?
 
     // NOTE: applicationDidResignActive removed — it was stealing focus from
     // Settings/Help windows, preventing sidebar clicks. Glass saturation is

--- a/widget/Sources/RubberDuckWidget/SerialTransport.swift
+++ b/widget/Sources/RubberDuckWidget/SerialTransport.swift
@@ -22,6 +22,23 @@ class SerialTransport: DeviceTransport {
     /// Board identity from handshake (e.g. "ESP32S3", "TEENSY40"). Nil until identified.
     private(set) var connectedBoard: String?
 
+    /// Hardware variant tag from handshake — "DUCKY_PCB" or "XIAO" on the
+    /// Claude Code Duck, or nil on older firmware that doesn't emit it.
+    /// Determines which firmware binary the updater would flash if it
+    /// were to flash.
+    private(set) var connectedVariant: String?
+
+    /// Firmware version reported by the duck — e.g. "cc-v0.1.4" on a
+    /// CI-built binary, nil on local-dev builds (no FIRMWARE_VERSION
+    /// flag was passed at compile time) or pre-versioning firmware.
+    /// FirmwareUpdater compares this to the version field in
+    /// cc-latest.json on the Pages-hosted manifest.
+    private(set) var connectedFirmwareVersion: String?
+
+    /// Fires once when a fresh handshake yields identity fields — lets
+    /// FirmwareUpdater notice "a duck plugged in" without polling.
+    var onIdentity: (() -> Void)?
+
     /// Thread-safe access to fileDescriptor and inAudioMode.
     /// These are written on the main thread but read from the audio streaming
     /// and serial read threads. Same pattern as TTSGate.
@@ -437,12 +454,23 @@ class SerialTransport: DeviceTransport {
         }
     }
 
-    /// Parse "DUCK,ESP32S3,1.0" identity response.
+    /// Parse "DUCK,<chip>,<protocol_ver>,<variant>[,<firmware_ver>]" identity response.
+    ///
+    /// Backward-compatible: 3-field replies still work (legacy Teensy
+    /// builds), 4-field replies fill in variant, 5-field replies (CI-
+    /// stamped Arduino builds, post-cc-v0.1.4) fill in firmware version
+    /// too. Missing fields stay nil, and FirmwareUpdater treats nil
+    /// version as "can't tell — no prompt."
     private func parseIdentity(_ line: String) {
         let parts = line.split(separator: ",")
         guard parts.count >= 3, parts[0] == "DUCK" else { return }
         connectedBoard = String(parts[1])
-        let version = String(parts[2])
-        print("[serial] Identified: \(connectedBoard!) v\(version)")
+        let protocolVersion = String(parts[2])
+        connectedVariant = parts.count >= 4 ? String(parts[3]) : nil
+        connectedFirmwareVersion = parts.count >= 5 ? String(parts[4]) : nil
+        let variantLog = connectedVariant.map { " [\($0)]" } ?? ""
+        let fwLog = connectedFirmwareVersion.map { " fw=\($0)" } ?? ""
+        print("[serial] Identified: \(connectedBoard!) proto=\(protocolVersion)\(variantLog)\(fwLog)")
+        onIdentity?()
     }
 }

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -15,6 +15,7 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
     private let serialManager: SerialManager
     private let duckServer: DuckServer
     var updateChecker: UpdateChecker?
+    var firmwareUpdater: FirmwareUpdater?
 
     init(speechService: SpeechService, coordinator: DuckCoordinator,
          serialManager: SerialManager, duckServer: DuckServer) {
@@ -114,6 +115,27 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
             if checker.isUpdateAvailable || checker.isPluginStale {
                 menu.addItem(.separator())
             }
+        }
+
+        // Duck firmware update — surfaces separately from the app/plugin
+        // updates because it's a different artifact (the .bin on the
+        // chip, not the .dmg on the Mac). Same visual rhythm so users
+        // already trained on "update available" notices recognize the
+        // pattern. Phase 1 hands off to the web flasher; phase 2 will
+        // add an in-app one-click flow that drives espflash directly.
+        if let updater = firmwareUpdater, updater.isFirmwareUpdateAvailable,
+           let manifest = updater.latestManifest {
+            let current = updater.connectedFirmwareVersion ?? "older"
+            let firmwareItem = NSMenuItem(
+                title: "Duck Firmware Update: \(manifest.version)",
+                action: #selector(openFirmwareFlasher),
+                keyEquivalent: ""
+            )
+            firmwareItem.target = self
+            firmwareItem.image = NSImage(systemSymbolName: "cpu", accessibilityDescription: "Firmware")
+            firmwareItem.subtitle = "Running \(current) — open flasher to update"
+            menu.addItem(firmwareItem)
+            menu.addItem(.separator())
         }
 
         // --- Volume slider ---
@@ -466,6 +488,16 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
 
     @objc private func updatePlugin() {
         PluginInstaller.install()
+    }
+
+    /// Hand off to the web flasher for firmware reflash. Phase 1: this
+    /// is the only path. Phase 2 will swap in an in-app sheet that
+    /// runs espflash against the connected duck without leaving the
+    /// widget; the web URL stays as the advanced/recovery fallback.
+    @objc private func openFirmwareFlasher() {
+        if let url = URL(string: FirmwareUpdater.webFlasherURL) {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     @objc private func installClaudeCLI() {


### PR DESCRIPTION
## Summary

Adds a status-bar menu item that surfaces "Duck Firmware Update Available" when the plugged-in Claude Code Duck is running older firmware than the latest published on Pages. Clicking the item opens the web flasher in the browser.

Phase 2 (bundling `espflash` for in-app one-click reflash) is deferred — this PR is the detection + hand-off path on its own, which is shippable and useful as-is. The web flasher remains the recovery path even after phase 2 lands.

## What's in this PR (single commit `b80936d`)

**Firmware** — `firmware/rubber_duck_s3{,_ducky}/SerialProtocol.ino`
- DUCK identity handshake gains an optional 5th comma-separated field for firmware version: `DUCK,ESP32S3,1.0,DUCKY_PCB,cc-v0.1.4`
- Backward-compatible: only emitted when sketch was compiled with `-DFIRMWARE_VERSION="..."`. Local dev builds without the flag still emit the 4-field form, which the widget treats as "version unknown → no prompt." Existing ducks in the field are unaffected.

**CI** — `.github/workflows/cc-firmware-release.yml`
- Stamps `-DFIRMWARE_VERSION="<git tag>"` into `build_opt.h` alongside the existing `-DUSB_SERIAL` stamp. Same tag-derived value reaches both the USB descriptor (web flasher reads via WebUSB) and the runtime identity reply (widget reads via serial).

**Widget**
- `SerialTransport.parseIdentity`: backward-compatibly captures the 4th (variant) and 5th (firmware version) fields. New `onIdentity` callback fires on every fresh handshake so listeners react without polling.
- `FirmwareUpdater.swift` (new): service modeled after `UpdateChecker` but watches the duck-on-USB instead of the Mac app. Fetches `docs/flash/firmware/cc-latest.json` every 12h (initial 35s after launch, staggered behind `UpdateChecker`'s 30s), compares, publishes `isFirmwareUpdateAvailable`. Quiet by design — no TTS callback, no nag for `nil` versions.
- `StatusBarManager`: new menu item between existing app/plugin update notices and the volume slider. Subtitle shows running version. Action opens the web flasher URL.
- `RubberDuckWidgetApp`: instantiates `FirmwareUpdater`, binds it to the serial transport, exposes via `AppDelegate.firmwareUpdater`.

## Why a separate service from `UpdateChecker`

The two watch different artifacts (chip `.bin` vs Mac `.dmg`), have different staleness signals (USB-serial handshake vs `CFBundleShortVersionString`), and the web-flasher hand-off is firmware-specific. Mixing them would tangle the menu logic and re-introduce the GitHub Releases coupling that was just stripped out of the firmware workflows in a previous PR.

## Validation

End-to-end test requires a `cc-v*` tag built through CI so the chip carries `FIRMWARE_VERSION` and the manifest gets a fresh version stamp. Compile passes (`swift build` clean), and the existing serial-identity parser is backward-compatible with the 4-field form so legacy ducks aren't disturbed.

## Test plan

- [ ] Push a `cc-v0.1.4` tag → CI publishes `cc-latest.json` with the new version + the new identity-aware binaries
- [ ] Flash a duck via the web flasher → reboot → widget should pick up the new version on next handshake
- [ ] Manually flash a duck with cc-v0.1.3 (no `FIRMWARE_VERSION`) → widget should show NO firmware update prompt (legacy duck, version unknown)
- [ ] Once new and old ducks coexist: widget on new duck = no prompt; widget on old duck → flash to new → menu prompt clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)