### PR TITLE
Cursor support + multi-tool Coding Tools pane

### DIFF
--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,0 +1,56 @@
+# Duck Duck Duck — Cursor integration
+
+These hooks connect the Duck Duck Duck widget to **Cursor** (1.7+), the same way
+the `plugin/` hooks connect it to Claude Code. The widget's eval server
+(`localhost:3333`) is shared — only the hook wiring differs, because Cursor's
+hook events and JSON payloads are shaped differently from Claude Code's.
+
+## One-click install (recommended)
+
+Launch the widget. If Cursor is installed, the duck offers to connect itself —
+or use the menu bar: **🦆 → Connect to Cursor**. That copies these scripts into
+`~/.duck-duck-duck/cursor-hooks/` and merges the hook
+wiring into `~/.cursor/hooks.json` (preserving any hooks you already have).
+Then reload Cursor (**Cmd+Shift+P → Reload Window**).
+
+## Hook mapping
+
+| Duck behavior              | Cursor hook(s)                                | Endpoint                         |
+| -------------------------- | --------------------------------------------- | -------------------------------- |
+| Score the user's prompt    | `beforeSubmitPrompt`                          | `POST /evaluate` (source=user)   |
+| Score the agent's reply    | `afterAgentResponse`                          | `POST /evaluate` (source=claude) |
+| "Cursor's waiting" chirp   | `beforeShellExecution` + `beforeMCPExecution` | `POST /activity` (state=pending) |
+| Clear the chirp on auto-run| `afterShellExecution`                         | `POST /activity` (state=resolved)|
+
+**The duck does NOT gate Cursor's permissions.** Cursor keeps its own approval
+UI and allow-list, and Cursor ignores a hook's `allow`/`ask` anyway (only `deny`
+is honored). So `on-permission.sh` is a *non-blocking notifier*: it fires a
+`pending` ping and returns instantly with no decision, leaving Cursor's native
+approve/deny untouched. The widget pairs `pending` with the `resolved` ping from
+`afterShellExecution`; if a command is still unresolved after a short grace
+period, Cursor is parked on its approve prompt and the duck chirps once. Auto-run
+commands resolve instantly and stay silent. (MCP has no confirmed resolve event
+yet, so MCP pings are recorded but never chirp — no false alarms.)
+
+We hook `beforeShellExecution` / `beforeMCPExecution` rather than the generic
+`preToolUse` on purpose: `preToolUse` fires before *every* tool (including each
+file read and edit), which would make the duck nag nonstop.
+
+Cursor's `stop` hook only reports a status string (no message text), so response
+scoring rides on `afterAgentResponse`, which carries the final assistant text.
+
+Every hook also tags its `POST` with `app` (`cursor`) and `repo` (workspace
+folder name) so the duck can say *which* tool/repo needs you when several run at
+once.
+
+## Manual install
+
+1. Copy this `hooks/` folder somewhere stable **with no spaces in the path**
+   (e.g. `~/.duck-duck-duck/cursor-hooks/`) and `chmod +x` the `*.sh` files.
+   Cursor runs each hook command through a shell, so a space in the path
+   (e.g. `Library/Application Support/…`) breaks it with exit 127.
+2. Take `hooks.template.json`, replace every `__HOOKS_DIR__` with the absolute
+   path to that folder, and merge it into `~/.cursor/hooks.json`.
+3. Reload Cursor.
+
+Requires Cursor 1.7 or newer (the release that introduced agent hooks).

--- a/cursor/hooks.template.json
+++ b/cursor/hooks.template.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      { "command": "__HOOKS_DIR__/on-before-submit-prompt.sh" }
+    ],
+    "afterAgentResponse": [
+      { "command": "__HOOKS_DIR__/on-after-agent-response.sh" }
+    ],
+    "beforeShellExecution": [
+      { "command": "__HOOKS_DIR__/on-permission.sh" }
+    ],
+    "beforeMCPExecution": [
+      { "command": "__HOOKS_DIR__/on-permission.sh" }
+    ],
+    "afterShellExecution": [
+      { "command": "__HOOKS_DIR__/on-after-shell.sh" }
+    ]
+  }
+}

--- a/cursor/hooks/duck-env.sh
+++ b/cursor/hooks/duck-env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# duck-env.sh — Rubber Duck runtime config for plugin hook scripts.
+# All values are hardcoded defaults matching DuckConfig.swift.
+# Override any value via environment variable before sourcing.
+# Zero external dependencies — uses python3 (ships with macOS) instead of jq.
+
+# Read dynamic port from widget's state file, fall back to default
+DUCK_PORT_FILE="${HOME}/Library/Application Support/DuckDuckDuck/port"
+if [ -z "${DUCK_SERVICE_PORT}" ] && [ -f "$DUCK_PORT_FILE" ]; then
+    DUCK_SERVICE_PORT=$(cat "$DUCK_PORT_FILE" 2>/dev/null)
+fi
+DUCK_SERVICE_PORT="${DUCK_SERVICE_PORT:-3333}"
+DUCK_SERVICE_URL="${DUCK_SERVICE_URL:-http://localhost:${DUCK_SERVICE_PORT}}"
+DUCK_TMUX_SESSION="${DUCK_TMUX_SESSION:-duck}"
+DUCK_TMUX_WINDOW="${DUCK_TMUX_WINDOW:-claude}"
+DUCK_VOICE="${DUCK_VOICE:-Boing}"
+
+# --- JSON helpers (python3, no jq needed) ---
+
+# Extract a field from JSON string. Usage: json_get "$JSON" "field" "default"
+json_get() {
+    python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+    keys = sys.argv[2].split('.')
+    v = d
+    for k in keys:
+        v = v.get(k, None) if isinstance(v, dict) else None
+        if v is None: break
+    print(v if v is not None else sys.argv[3] if len(sys.argv) > 3 else '')
+except: print(sys.argv[3] if len(sys.argv) > 3 else '')
+" "$1" "$2" "${3:-}"
+}
+
+# Build a JSON object from key=value pairs. Usage: json_build key1 val1 key2 val2 ...
+json_build() {
+    python3 -c "
+import json, sys
+d = {}
+args = sys.argv[1:]
+for i in range(0, len(args), 2):
+    if i+1 < len(args): d[args[i]] = args[i+1]
+print(json.dumps(d))
+" "$@"
+}

--- a/cursor/hooks/on-after-agent-response.sh
+++ b/cursor/hooks/on-after-agent-response.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Cursor hook: afterAgentResponse — fires when the Cursor agent finishes its
+# turn, carrying the final assistant text. The Claude Code analogue is Stop
+# (which we drive off last_assistant_message). We use afterAgentResponse rather
+# than Cursor's `stop` hook because `stop` only reports a status string with no
+# message text — there'd be nothing to score. Forwarded to /evaluate with
+# source="claude" so the duck reacts to the agent's answer.
+#
+# Cursor stdin (see https://cursor.com/docs/hooks):
+#   { "text": "<assistant final text>", "conversation_id", "generation_id",
+#     "model", "hook_event_name": "afterAgentResponse" }
+# stdout: no output fields supported — emit nothing.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/duck-env.sh"
+
+INPUT=$(cat)
+
+LAST_MESSAGE=$(json_get "$INPUT" "text")
+SESSION_ID=$(json_get "$INPUT" "conversation_id")
+REPO=$(python3 -c "
+import json, sys, os
+try:
+    d = json.loads(sys.argv[1]); r = d.get('workspace_roots') or []
+    print(os.path.basename(r[0].rstrip('/')) if r else '')
+except: print('')
+" "$INPUT")
+
+# Skip empty responses
+if [ -z "$LAST_MESSAGE" ] || [ "$LAST_MESSAGE" = "null" ] || [ "$LAST_MESSAGE" = "None" ]; then
+  exit 0
+fi
+
+PAYLOAD=$(json_build \
+  session_id "$SESSION_ID" \
+  timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  source "claude" \
+  app "cursor" \
+  repo "$REPO" \
+  text "$LAST_MESSAGE")
+
+curl -s -X POST "${DUCK_SERVICE_URL}/evaluate" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" > /dev/null 2>&1
+
+exit 0

--- a/cursor/hooks/on-after-shell.sh
+++ b/cursor/hooks/on-after-shell.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Cursor hook: afterShellExecution — observe-only.
+#
+# Fires after a shell command actually runs (i.e. after any approval). We pair
+# it with the "pending" ping from on-permission.sh: this "resolved" ping cancels
+# the duck's pending-timer for that command, so an auto-approved (fast) command
+# never chirps. Keyed on conversation_id + command, which both events carry.
+#
+# Fire-and-forget and non-blocking, same as the pending side.
+#
+# Cursor stdin: { command, output, duration, sandbox, conversation_id, ... }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/duck-env.sh"
+
+INPUT=$(cat)
+
+BODY=$(python3 -c "
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+except Exception:
+    print('{}'); sys.exit(0)
+print(json.dumps({
+    'state': 'resolved',
+    'kind': 'shell',
+    'conversation_id': d.get('conversation_id', ''),
+    'command': d.get('command', ''),
+}))
+" "$INPUT")
+
+( curl -s -m 2 -X POST "${DUCK_SERVICE_URL}/activity" \
+    -H "Content-Type: application/json" \
+    -d "$BODY" >/dev/null 2>&1 & )
+
+exit 0

--- a/cursor/hooks/on-before-submit-prompt.sh
+++ b/cursor/hooks/on-before-submit-prompt.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Cursor hook: beforeSubmitPrompt — fires when the user submits a prompt to the
+# Cursor agent, before it hits Cursor's backend. The Claude Code analogue is
+# UserPromptSubmit. We forward the prompt to the duck's /evaluate endpoint with
+# source="user" so the duck scores and reacts to what the user just asked.
+#
+# Cursor stdin (see https://cursor.com/docs/hooks):
+#   { "conversation_id", "generation_id", "prompt", "attachments",
+#     "hook_event_name": "beforeSubmitPrompt", "workspace_roots" }
+# stdout: informational only — we don't block prompts, so emit nothing.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/duck-env.sh"
+
+INPUT=$(cat)
+
+PROMPT=$(json_get "$INPUT" "prompt")
+SESSION_ID=$(json_get "$INPUT" "conversation_id")
+# repo = basename of the workspace root, computed here (clean string).
+REPO=$(python3 -c "
+import json, sys, os
+try:
+    d = json.loads(sys.argv[1]); r = d.get('workspace_roots') or []
+    print(os.path.basename(r[0].rstrip('/')) if r else '')
+except: print('')
+" "$INPUT")
+
+# Skip empty prompts
+if [ -z "$PROMPT" ] || [ "$PROMPT" = "null" ]; then
+  exit 0
+fi
+
+PAYLOAD=$(json_build \
+  session_id "$SESSION_ID" \
+  timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  source "user" \
+  app "cursor" \
+  repo "$REPO" \
+  text "$PROMPT")
+
+curl -s -X POST "${DUCK_SERVICE_URL}/evaluate" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" > /dev/null 2>&1
+
+exit 0

--- a/cursor/hooks/on-permission.sh
+++ b/cursor/hooks/on-permission.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Cursor hook: beforeShellExecution + beforeMCPExecution.
+#
+# This is a NON-BLOCKING NOTIFIER, not a permission gate. Cursor owns its own
+# approval UI and allow-list, and Cursor's hook "ask"/"allow" responses are
+# ignored anyway (only "deny" is honored) — so the duck deliberately does NOT
+# influence the decision. It fires a fire-and-forget "pending" ping to the
+# widget and returns instantly with NO decision, leaving Cursor's native
+# approve/deny flow 100% untouched.
+#
+# The widget pairs this "pending" with the matching "resolved" ping from
+# on-after-shell.sh: if the command runs within a short grace period it was
+# auto-approved (stay silent); if it's still unresolved, Cursor is parked on its
+# approve prompt waiting for the user, and the duck chirps once.
+#
+# Why fire-and-forget (backgrounded curl, not --max-time): Cursor BLOCKS its
+# agent loop until this hook process exits. Any wait here re-freezes the very
+# approve UI we're trying to leave responsive. So we detach the POST and return.
+#
+# Cursor stdin (see https://cursor.com/docs/hooks):
+#   beforeShellExecution: { command, cwd, conversation_id, workspace_roots, ... }
+#   beforeMCPExecution:   { tool_name, tool_input, conversation_id, workspace_roots, ... }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/duck-env.sh"
+
+INPUT=$(cat)
+
+# Build the /activity "pending" body. Repo basename is computed HERE (clean,
+# slash-free) so the server never has to parse a path back out of escaped JSON.
+BODY=$(python3 -c "
+import json, sys, os
+try:
+    d = json.loads(sys.argv[1])
+except Exception:
+    print('{}'); sys.exit(0)
+event = d.get('hook_event_name', 'beforeShellExecution')
+roots = d.get('workspace_roots') or []
+repo = os.path.basename(roots[0].rstrip('/')) if roots else ''
+out = {
+    'state': 'pending',
+    'app': 'cursor',
+    'repo': repo,
+    'conversation_id': d.get('conversation_id', ''),
+}
+if event == 'beforeMCPExecution':
+    out['kind'] = 'mcp'
+    out['tool'] = d.get('tool_name', '')
+else:
+    out['kind'] = 'shell'
+    out['command'] = d.get('command', '')
+print(json.dumps(out))
+" "$INPUT")
+
+# Fire-and-forget: detached subshell so the hook never waits on the POST.
+# A short -m guards against a wedged connection leaving stray curls around;
+# the hook's exit does not depend on it.
+( curl -s -m 2 -X POST "${DUCK_SERVICE_URL}/activity" \
+    -H "Content-Type: application/json" \
+    -d "$BODY" >/dev/null 2>&1 & )
+
+# No decision — return immediately so Cursor's own approval flow is untouched.
+echo '{}'
+exit 0

--- a/plugin/hooks/on-claude-stop.sh
+++ b/plugin/hooks/on-claude-stop.sh
@@ -11,6 +11,9 @@ LAST_MESSAGE=$(json_get "$INPUT" "last_assistant_message")
 SESSION_ID=$(json_get "$INPUT" "session_id")
 TRANSCRIPT_PATH=$(json_get "$INPUT" "transcript_path")
 STOP_HOOK_ACTIVE=$(json_get "$INPUT" "stop_hook_active" "false")
+CWD=$(json_get "$INPUT" "cwd")
+REPO=$(basename "$CWD" 2>/dev/null)
+[ "$REPO" = "/" ] && REPO=""
 
 # Prevent infinite loop if Stop hook re-triggers
 if [ "$STOP_HOOK_ACTIVE" = "true" ]; then
@@ -71,6 +74,8 @@ PAYLOAD=$(json_build \
   session_id "$SESSION_ID" \
   timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   source "claude" \
+  app "claude-code" \
+  repo "$REPO" \
   text "$LAST_MESSAGE" \
   user_context "$LAST_USER")
 

--- a/plugin/hooks/on-user-prompt.sh
+++ b/plugin/hooks/on-user-prompt.sh
@@ -9,6 +9,11 @@ INPUT=$(cat)
 
 PROMPT=$(json_get "$INPUT" "prompt")
 SESSION_ID=$(json_get "$INPUT" "session_id")
+# repo = basename of the session's working directory (for attribution when
+# multiple tools/repos run at once). Empty if cwd is missing.
+CWD=$(json_get "$INPUT" "cwd")
+REPO=$(basename "$CWD" 2>/dev/null)
+[ "$REPO" = "/" ] && REPO=""
 
 # Skip empty prompts
 if [ -z "$PROMPT" ] || [ "$PROMPT" = "null" ]; then
@@ -19,6 +24,8 @@ PAYLOAD=$(json_build \
   session_id "$SESSION_ID" \
   timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
   source "user" \
+  app "claude-code" \
+  repo "$REPO" \
   text "$PROMPT")
 
 curl -s -X POST "${DUCK_SERVICE_URL}/evaluate" \

--- a/widget/Makefile
+++ b/widget/Makefile
@@ -44,6 +44,13 @@ bundle: build icon
 	@PLUGIN_V=$$(python3 -c 'import json; print(json.load(open("../plugin/.claude-plugin/plugin.json"))["version"])'); \
 		APP_V=$$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" Info.plist); \
 		echo "📦 Bundled plugin v$$PLUGIN_V in app v$$APP_V"
+	@# Cursor adapter hooks — copied alongside the plugin so CursorInstaller
+	@# can find them in Resources/cursor/ and wire them into ~/.cursor/hooks.json.
+	@rm -rf $(RESOURCES_DIR)/cursor
+	@cp -R ../cursor $(RESOURCES_DIR)/cursor
+	@test -f $(RESOURCES_DIR)/cursor/hooks/on-permission.sh \
+		|| (echo "❌ Bundled cursor hooks missing — build aborted"; exit 1)
+	@echo "📦 Bundled Cursor adapter hooks"
 	@codesign --force --deep --sign - $(APP_BUNDLE)
 	@echo "✅ Built $(APP_BUNDLE)"
 

--- a/widget/Sources/RubberDuckWidget/CursorActivityMonitor.swift
+++ b/widget/Sources/RubberDuckWidget/CursorActivityMonitor.swift
@@ -1,0 +1,154 @@
+// Cursor Activity Monitor — derives "Cursor is parked waiting for the user to
+// approve a command" and chirps once, WITHOUT influencing Cursor's decision.
+//
+// Cursor never tells a hook whether a command will require approval — the hook
+// path and Cursor's own approval path are separate, and beforeShellExecution
+// fires identically for auto-run and prompt-me commands. So we derive it from
+// timing: a command that's still unresolved a couple seconds after its
+// beforeShellExecution is one Cursor is sitting on, waiting for the user.
+//
+//   on-permission.sh   (beforeShellExecution) → POST /activity {state:"pending"}
+//   on-after-shell.sh  (afterShellExecution)  → POST /activity {state:"resolved"}
+//
+// pending arms a self-cleaning timer; resolved cancels it. Timer survives →
+// chirp. Auto-approved commands resolve in milliseconds → silent.
+//
+// Hardened against the real failure modes (see the design review):
+//  - Order-tolerant: MiniServer spawns an independent Task per request with NO
+//    ordering guarantee, so "resolved" can land before "pending". resolvedEarly
+//    absorbs that.
+//  - Self-cleaning: a fired timer removes its own entry, so a DENIED/cancelled
+//    command (whose afterShellExecution never fires) can't leak an entry.
+//  - MainActor + DispatchWorkItem timer (the proven thinkingTimeout pattern) —
+//    a bare Timer on the server's GCD queue would silently never fire.
+//  - Per-repo cooldown + coalescing so rapid commands chirp at most once.
+//  - MCP pendings are recorded as no-ops (no afterMCPExecution resolve signal is
+//    confirmed yet, so arming a timer would guarantee false alarms).
+
+import Foundation
+
+@MainActor
+final class CursorActivityMonitor {
+    /// How long a command may stay unresolved before we treat Cursor as parked
+    /// on its approve prompt. Tuned above typical auto-run latency so a fast
+    /// allow-listed command is clearly excluded.
+    private let parkedThreshold: TimeInterval = 2.5
+    /// Don't re-chirp for the same repo more often than this.
+    private let repoCooldown: TimeInterval = 30
+    /// Drop resolvedEarly markers older than this (bounds the set).
+    private let resolvedEarlyTTL: TimeInterval = 10
+    /// Hard cap on live pending entries (runaway backstop).
+    private let maxPending = 32
+
+    private struct Pending {
+        let work: DispatchWorkItem
+        let repo: String
+        let app: String
+        let at: Date
+    }
+
+    private var pending: [String: Pending] = [:]
+    private var resolvedEarly: [String: Date] = [:]
+    private var lastChirpByRepo: [String: Date] = [:]
+
+    /// Set by the app: speaks a single short ambient line (drops if busy).
+    var onChirp: ((String) -> Void)?
+
+    // MARK: - Hook events (called on MainActor from the /activity handler)
+
+    /// A command is about to run. shell → arm the parked-timer; mcp → ignore
+    /// (no confirmed resolve signal, so a timer would always false-fire).
+    func handlePending(kind: String, conversationId: String, command: String, repo: String, app: String) {
+        guard kind == "shell" else { return }
+        let key = Self.key(conversationId, command)
+
+        evictStaleResolvedEarly()
+
+        // Already resolved before we registered (out-of-order race) → it ran
+        // fast, nothing to announce.
+        if let t = resolvedEarly[key], Date().timeIntervalSince(t) <= resolvedEarlyTTL {
+            resolvedEarly.removeValue(forKey: key)
+            return
+        }
+        // Idempotent: a duplicate pending for a live key must not re-arm.
+        if pending[key] != nil { return }
+
+        if pending.count >= maxPending { dropOldestPending() }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.fire(key: key, repo: repo, app: app)
+        }
+        pending[key] = Pending(work: work, repo: repo, app: app, at: Date())
+        DispatchQueue.main.asyncAfter(deadline: .now() + parkedThreshold, execute: work)
+    }
+
+    /// A command actually ran (post-approval). Cancel its pending timer; if it
+    /// arrives before the matching pending was registered, remember it briefly.
+    func handleResolved(conversationId: String, command: String) {
+        let key = Self.key(conversationId, command)
+        if let p = pending.removeValue(forKey: key) {
+            p.work.cancel()
+        } else {
+            evictStaleResolvedEarly()
+            resolvedEarly[key] = Date()
+        }
+    }
+
+    /// Cancel everything (app shutdown / server stop).
+    func clearAll() {
+        for p in pending.values { p.work.cancel() }
+        pending.removeAll()
+        resolvedEarly.removeAll()
+        lastChirpByRepo.removeAll()
+    }
+
+    // MARK: - Internals
+
+    private func fire(key: String, repo: String, app: String) {
+        // Self-cleaning: remove our own entry whether or not we end up chirping.
+        pending.removeValue(forKey: key)
+
+        guard AppDelegate.isDuckActive else { return }
+
+        // Per-repo cooldown so a burst of parked commands chirps once.
+        let now = Date()
+        if let last = lastChirpByRepo[repo], now.timeIntervalSince(last) < repoCooldown {
+            return
+        }
+        lastChirpByRepo[repo] = now
+
+        onChirp?(Self.message(app: app, repo: repo))
+    }
+
+    private func dropOldestPending() {
+        guard let oldest = pending.min(by: { $0.value.at < $1.value.at }) else { return }
+        oldest.value.work.cancel()
+        pending.removeValue(forKey: oldest.key)
+    }
+
+    private func evictStaleResolvedEarly() {
+        let now = Date()
+        resolvedEarly = resolvedEarly.filter { now.timeIntervalSince($0.value) <= resolvedEarlyTTL }
+    }
+
+    /// Key on conversation_id + command — both events carry these, and there's
+    /// no per-command id in Cursor's payloads. \u{1} can't appear in either part.
+    private static func key(_ conversationId: String, _ command: String) -> String {
+        conversationId + "\u{1}" + command
+    }
+
+    private static func displayName(_ app: String) -> String {
+        switch app {
+        case "cursor": return "Cursor"
+        case "claude-code": return "Claude"
+        default: return app.isEmpty ? "Your agent" : app
+        }
+    }
+
+    /// app + repo only — never the command (privacy + length + no-spam tone).
+    private static func message(app: String, repo: String) -> String {
+        let name = displayName(app)
+        return repo.isEmpty ? "\(name)'s waiting on you to approve something."
+                            : "\(name)'s waiting on you in \(repo)."
+    }
+}

--- a/widget/Sources/RubberDuckWidget/CursorInstaller.swift
+++ b/widget/Sources/RubberDuckWidget/CursorInstaller.swift
@@ -1,0 +1,293 @@
+// Cursor Installer — one-click wiring of the duck's hooks into Cursor (1.7+).
+//
+// Cursor gained an agent-lifecycle hooks system in 1.7. Unlike Claude Code
+// (which we reach via a marketplace plugin), Cursor reads a plain JSON config
+// at ~/.cursor/hooks.json that points at executable scripts. So "installing"
+// for Cursor means:
+//   1. Copy the bundled cursor/hooks/* adapter scripts to a stable location
+//      (Application Support — survives app updates, lives outside the .app).
+//   2. Merge our four hook entries into ~/.cursor/hooks.json with ABSOLUTE
+//      paths, preserving any hooks the user already configured.
+//   3. Tell the user to reload Cursor.
+//
+// The adapter scripts translate Cursor's hook JSON shapes into the same
+// /evaluate and /permission calls the Claude Code hooks make, so the widget's
+// server is untouched and the two editors can run side by side.
+//
+// No sandbox: this build is GitHub-release only (see project memory / CLAUDE.md),
+// so writing ~/.cursor/hooks.json directly is allowed — that's the whole reason
+// the one-click flow is possible.
+
+import AppKit
+
+enum CursorInstaller {
+    /// Callback for voice feedback during install. Set by the app on launch
+    /// (mirrors PluginInstaller.onSpeak).
+    @MainActor static var onSpeak: ((String) -> Void)?
+
+    /// Where the adapter scripts get copied to. Deliberately a SPACE-FREE path
+    /// under the home dir — NOT Application Support. Cursor runs each hook's
+    /// `command` through `zsh`, and a space in the path ("Application Support")
+    /// breaks the command (exit 127: "no such file or directory: …/Library/Application").
+    /// A path with no spaces is safe no matter how Cursor spawns the process.
+    private static var installedHooksDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".duck-duck-duck/cursor-hooks")
+    }
+
+    /// ~/.cursor/hooks.json — Cursor's user-global hook config.
+    private static var cursorConfigURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cursor/hooks.json")
+    }
+
+    // The hooks we own, and which adapter script backs each. One script
+    // (on-permission.sh) serves both permission events.
+    private static let hookScripts: [(event: String, script: String)] = [
+        ("beforeSubmitPrompt", "on-before-submit-prompt.sh"),
+        ("afterAgentResponse", "on-after-agent-response.sh"),
+        ("beforeShellExecution", "on-permission.sh"),
+        ("beforeMCPExecution", "on-permission.sh"),
+        ("afterShellExecution", "on-after-shell.sh"),
+    ]
+
+    /// Recognize our own hook entries by script filename rather than by install
+    /// directory. This survives the install path changing (e.g. the move off
+    /// Application Support) — old entries from a prior path are still matched,
+    /// so re-Connect cleanly replaces them instead of stacking duplicates.
+    private static func isOurCommand(_ command: String) -> Bool {
+        let names = Set(hookScripts.map(\.script))
+        return names.contains { command.hasSuffix("/\($0)") || command == $0 }
+    }
+
+    // MARK: - Detection
+
+    /// Is Cursor installed? Checks Launch Services by bundle id (works even if
+    /// never launched), then falls back to the common app locations.
+    static func isCursorInstalled() -> Bool {
+        // Cursor ships under a ToDesktop bundle id.
+        if let urls = LSCopyApplicationURLsForBundleIdentifier(
+            "com.todesktop.230313mzl4w4u92" as CFString, nil
+        )?.takeRetainedValue() as? [URL], !urls.isEmpty {
+            return true
+        }
+        let fm = FileManager.default
+        let home = fm.homeDirectoryForCurrentUser.path
+        for path in ["/Applications/Cursor.app", "\(home)/Applications/Cursor.app"] {
+            if fm.fileExists(atPath: path) { return true }
+        }
+        // ~/.cursor exists once Cursor has run at least once.
+        return fm.fileExists(atPath: "\(home)/.cursor")
+    }
+
+    /// Are our hooks already wired into ~/.cursor/hooks.json?
+    ///
+    /// We PARSE the JSON rather than substring-matching the raw file: JSONSerialization
+    /// escapes "/" as "\/" on write, so a raw `.contains` on the on-disk text would miss.
+    /// Parsed command strings are unescaped, so matching our script names works.
+    static func areHooksInstalled() -> Bool {
+        guard let data = try? Data(contentsOf: cursorConfigURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"] as? [String: Any] else {
+            return false
+        }
+        for (_, value) in hooks {
+            guard let entries = value as? [[String: Any]] else { continue }
+            for entry in entries {
+                if let cmd = entry["command"] as? String, isOurCommand(cmd) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    // MARK: - Install
+
+    /// Entry point for the menu / spoken offer. Copies scripts, merges config,
+    /// then guides the user to reload Cursor.
+    @MainActor
+    static func install() {
+        guard isCursorInstalled() else {
+            onSpeak?("I don't see Cursor on this Mac.")
+            showResult(success: false,
+                       detail: "Cursor doesn't appear to be installed. Install Cursor 1.7 or newer, then try again.")
+            return
+        }
+        onSpeak?("Wiring myself into Cursor. One sec.")
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                let dir = try copyBundledScripts()
+                try mergeConfig(hooksDir: dir)
+                Task { @MainActor in
+                    onSpeak?("Done. Reload Cursor and I'll be watching.")
+                    showResult(success: true, detail: """
+                        Hooks installed for Cursor.
+
+                        Reload Cursor to activate them:
+                        Cmd+Shift+P → “Reload Window”.
+                        """)
+                }
+            } catch {
+                DuckLog.log("[cursor] install failed: \(error)")
+                Task { @MainActor in
+                    onSpeak?("Something went wrong wiring up Cursor.")
+                    showResult(success: false, detail: "Install failed:\n\(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    /// Copy the bundled cursor/hooks folder into Application Support and make
+    /// the scripts executable. Returns the destination directory.
+    private static func copyBundledScripts() throws -> URL {
+        guard let bundled = findBundledHooks() else {
+            throw CursorError.bundledHooksMissing
+        }
+        let fm = FileManager.default
+        let dest = installedHooksDir
+
+        // Replace any prior copy so updates land cleanly.
+        try? fm.removeItem(at: dest)
+        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
+
+        for item in try fm.contentsOfDirectory(atPath: bundled.path) {
+            let src = bundled.appendingPathComponent(item)
+            let dst = dest.appendingPathComponent(item)
+            try fm.copyItem(at: src, to: dst)
+            if item.hasSuffix(".sh") {
+                try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: dst.path)
+            }
+        }
+        DuckLog.log("[cursor] copied adapter scripts to \(dest.path)")
+        return dest
+    }
+
+    /// Merge our hook entries into ~/.cursor/hooks.json, preserving the user's
+    /// existing hooks and dropping any stale duck entries from a prior install.
+    private static func mergeConfig(hooksDir: URL) throws {
+        let fm = FileManager.default
+        let url = cursorConfigURL
+        try fm.createDirectory(at: url.deletingLastPathComponent(),
+                               withIntermediateDirectories: true)
+
+        // Load existing config (if any and valid), else start fresh.
+        var root: [String: Any] = ["version": 1, "hooks": [:]]
+        if let data = fm.contents(atPath: url.path),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            root = json
+            if root["version"] == nil { root["version"] = 1 }
+        }
+        var hooks = root["hooks"] as? [String: Any] ?? [:]
+
+        for (event, script) in hookScripts {
+            let command = hooksDir.appendingPathComponent(script).path
+            // Keep the user's other hooks for this event; drop only ours
+            // (identified by script filename) so re-installing doesn't stack
+            // duplicates — including stale entries from an older install path.
+            var entries = (hooks[event] as? [[String: Any]] ?? []).filter { entry in
+                guard let cmd = entry["command"] as? String else { return true }
+                return !isOurCommand(cmd)
+            }
+            entries.append(["command": command])
+            hooks[event] = entries
+        }
+        root["hooks"] = hooks
+
+        let out = try JSONSerialization.data(withJSONObject: root,
+                                             options: [.prettyPrinted, .sortedKeys])
+        try out.write(to: url, options: .atomic)
+        DuckLog.log("[cursor] merged hooks into \(url.path)")
+    }
+
+    // MARK: - Uninstall
+
+    /// Remove our hook entries (and empty event arrays) from hooks.json. Leaves
+    /// the user's own hooks intact. The copied scripts are left in place — they
+    /// do nothing once unreferenced — but we remove them too for tidiness.
+    @MainActor
+    static func uninstall() {
+        let fm = FileManager.default
+        let url = cursorConfigURL
+        if let data = fm.contents(atPath: url.path),
+           var root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           var hooks = root["hooks"] as? [String: Any] {
+            for (event, _) in hookScripts {
+                guard var entries = hooks[event] as? [[String: Any]] else { continue }
+                entries.removeAll { ($0["command"] as? String).map(isOurCommand) == true }
+                if entries.isEmpty { hooks.removeValue(forKey: event) } else { hooks[event] = entries }
+            }
+            root["hooks"] = hooks
+            if let out = try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys]) {
+                try? out.write(to: url, options: .atomic)
+            }
+        }
+        try? fm.removeItem(at: installedHooksDir)
+        onSpeak?("Disconnected from Cursor.")
+        DuckLog.log("[cursor] uninstalled hooks")
+    }
+
+    // MARK: - Bundled location
+
+    /// Find the bundled cursor/hooks folder — inside the app bundle Resources,
+    /// or next to the running app during dev. Mirrors PluginInstaller.findBundledPlugin.
+    private static func findBundledHooks() -> URL? {
+        let fm = FileManager.default
+        if let resourcePath = Bundle.main.resourcePath {
+            let dir = URL(fileURLWithPath: resourcePath)
+                .appendingPathComponent("cursor/hooks")
+            if fm.fileExists(atPath: dir.appendingPathComponent("on-permission.sh").path) {
+                return dir
+            }
+        }
+        // Dev layout: walk up from the bundle to the repo root and use cursor/hooks.
+        var candidate = Bundle.main.bundleURL
+        for _ in 0..<10 {
+            candidate = candidate.deletingLastPathComponent()
+            let dir = candidate.appendingPathComponent("cursor/hooks")
+            if fm.fileExists(atPath: dir.appendingPathComponent("on-permission.sh").path) {
+                return dir
+            }
+        }
+        return nil
+    }
+
+    // MARK: - First-run spoken offer
+
+    /// UserDefaults key tracking the last app version for which we voiced the
+    /// Cursor offer — so we suggest it once per version, not every launch.
+    private static var offerShownVersion: String? {
+        get { UserDefaults.standard.string(forKey: "cursorOfferShownVersion") }
+        set { UserDefaults.standard.set(newValue, forKey: "cursorOfferShownVersion") }
+    }
+
+    /// Called shortly after launch. If Cursor is installed but our hooks aren't
+    /// wired up yet, the duck offers — out loud — to connect itself. Fires at
+    /// most once per app version so it doesn't nag.
+    @MainActor
+    static func offerIfAppropriate() {
+        guard isCursorInstalled(), !areHooksInstalled() else { return }
+        let running = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        guard offerShownVersion != running else { return }
+        offerShownVersion = running
+        DuckLog.log("[cursor] offering Cursor hook install (v\(running))")
+        onSpeak?("Oh — you've got Cursor. I work there now too. Hit Connect to Cursor in my menu.")
+    }
+
+    // MARK: - Result alert
+
+    @MainActor
+    private static func showResult(success: Bool, detail: String) {
+        showInstallResult(title: "Cursor Hooks Installed", success: success, detail: detail)
+    }
+
+    enum CursorError: LocalizedError {
+        case bundledHooksMissing
+        var errorDescription: String? {
+            switch self {
+            case .bundledHooksMissing:
+                return "Couldn't find the bundled Cursor hook scripts inside the app."
+            }
+        }
+    }
+}

--- a/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
+++ b/widget/Sources/RubberDuckWidget/DuckCoordinator.swift
@@ -46,6 +46,22 @@ class DuckCoordinator: ObservableObject {
     private var lastShyReactionAt: Date?
     private var lastShyAckAt: Date?
 
+    // Multi-tool attribution. We name the program ONLY for agent output (you
+    // already know what you did), ONLY on a real switch from the last agent
+    // reaction, and ONLY after a gap (so ping-ponging between tools doesn't
+    // label every line). Never names the repo in a reaction.
+    private var lastAgentReactionApp: String?
+    private var lastAgentReactionAt: Date?
+    private let attributionGap: TimeInterval = 45
+
+    private static func appDisplayName(_ app: String) -> String? {
+        switch app {
+        case "cursor": return "Cursor"
+        case "claude-code": return "Claude"
+        default: return nil
+        }
+    }
+
     init(evalService: EvalService, speechService: SpeechService, serialManager: SerialManager) {
         self.evalService = evalService
         self.speechService = speechService
@@ -134,6 +150,22 @@ class DuckCoordinator: ObservableObject {
         case .walkieTalkie:
             textToSpeak = isUserEval ? "" : evalService.summary
         }
+
+        // Attribution: name the program only for the AGENT's output, only on a
+        // real switch from the last agent reaction, and only after a gap. User
+        // prompts are never named (you know what you typed). See properties above.
+        if !isUserEval && !textToSpeak.isEmpty {
+            let app = evalService.app
+            let now = Date()
+            let switched = lastAgentReactionApp != nil && app != lastAgentReactionApp
+            let gapPassed = lastAgentReactionAt.map { now.timeIntervalSince($0) > attributionGap } ?? true
+            if switched && gapPassed, let name = Self.appDisplayName(app) {
+                textToSpeak = "Over in \(name): \(textToSpeak)"
+            }
+            lastAgentReactionApp = app
+            lastAgentReactionAt = now
+        }
+
         // Track whether the upcoming utterance is a shy ack — if so, we'll
         // bypass wildcard voice selection (slow/musical voices butcher
         // ultra-short text like "ah" or "ooh" into silence).

--- a/widget/Sources/RubberDuckWidget/DuckIntegration.swift
+++ b/widget/Sources/RubberDuckWidget/DuckIntegration.swift
@@ -1,0 +1,131 @@
+// Duck Integrations — the set of coding tools the duck can watch.
+//
+// The widget's eval server (localhost:3333) is shared, so the duck can be wired
+// into several tools at once: a Claude Code session, a Cursor agent, and a
+// Gemini CLI session all POST to the same /evaluate and /permission endpoints.
+// What differs per tool is only the install mechanism (Claude = marketplace
+// plugin, Cursor = ~/.cursor/hooks.json, Gemini = CLI extension) and the
+// fidelity of the connection.
+//
+// This file unifies those behind one protocol so the Coding Tools preferences
+// pane can render them as a single checklist. Each conformer is a thin wrapper
+// over the existing installer (PluginInstaller / CursorInstaller /
+// GeminiExtensionInstaller); adding a new tool later (Windsurf, Copilot, …) is
+// one new conformer plus a line in `all`.
+
+import Foundation
+
+/// How completely a tool can talk to the duck. Not all integrations are equal —
+/// the checklist should say so rather than imply parity.
+enum IntegrationFidelity {
+    /// Scores prompts/responses AND relays permission decisions (voice yes/no
+    /// actually gates the action). Claude Code.
+    case full
+    /// Scores prompts/responses and NOTIFIES when the tool is waiting on you,
+    /// but never gates — the tool owns approval, the duck only chirps. Cursor.
+    case notify
+    /// Scores prompts/responses only; can't gate or reliably notify. Gemini CLI.
+    case observeOnly
+}
+
+// NOTE: the detection members are deliberately NOT @MainActor. They shell out
+// (`which claude`, Launch Services lookups, filesystem scans) and MUST be called
+// off the main thread — calling them during a SwiftUI view render spins the main
+// runloop via Process.waitUntilExit and re-enters AttributeGraph, which aborts.
+// Only connect()/disconnect() are @MainActor (they speak / show alerts).
+// Sendable: conformers are immutable value types, so they cross threads safely
+// (ToolsModel reads their detection off a background queue).
+protocol DuckIntegration: Sendable {
+    /// Stable identifier (used for SwiftUI list identity).
+    var id: String { get }
+    /// Display name, e.g. "Claude Code".
+    var displayName: String { get }
+    /// SF Symbol for the row.
+    var iconSystemName: String { get }
+    /// Is the underlying tool installed on this Mac? (Blocking — call off-main.)
+    var isToolInstalled: Bool { get }
+    /// Are the duck's hooks currently wired into it? (Blocking — call off-main.)
+    var isConnected: Bool { get }
+    /// What the duck can and can't do through this tool.
+    var fidelity: IntegrationFidelity { get }
+    /// One-line caveat shown under the row when relevant (nil = nothing to say).
+    var capabilityNote: String? { get }
+    /// Where to send the user if the tool itself isn't installed (nil = no link).
+    var installToolURL: URL? { get }
+
+    /// Wire the duck's hooks into this tool.
+    @MainActor func connect()
+    /// Remove the duck's hooks (best-effort).
+    @MainActor func disconnect()
+}
+
+extension DuckIntegration {
+    var fidelityLabel: String {
+        switch fidelity {
+        case .full: return "Scores + voice permissions"
+        case .notify: return "Scores + waiting-for-you alerts"
+        case .observeOnly: return "Scores only (approve in the tool)"
+        }
+    }
+}
+
+// MARK: - Claude Code
+
+struct ClaudeCodeIntegration: DuckIntegration {
+    let id = "claude-code"
+    let displayName = "Claude Code"
+    let iconSystemName = "terminal.fill"
+    let fidelity: IntegrationFidelity = .full
+    var isToolInstalled: Bool { PluginInstaller.isClaudeAvailable() }
+    var isConnected: Bool { PluginInstaller.isPluginInstalled() }
+    var capabilityNote: String? { nil }
+    var installToolURL: URL? { URL(string: "https://claude.com/download") }
+
+    @MainActor func connect() { PluginInstaller.install() }
+    @MainActor func disconnect() { PluginInstaller.uninstall() }
+}
+
+// MARK: - Cursor
+
+struct CursorIntegration: DuckIntegration {
+    let id = "cursor"
+    let displayName = "Cursor"
+    let iconSystemName = "cursorarrow.rays"
+    let fidelity: IntegrationFidelity = .notify
+    var isToolInstalled: Bool { CursorInstaller.isCursorInstalled() }
+    var isConnected: Bool { CursorInstaller.areHooksInstalled() }
+    var capabilityNote: String? {
+        "Cursor owns approvals; the duck just chirps when Cursor's waiting on you. Never blocks or decides."
+    }
+    var installToolURL: URL? { URL(string: "https://cursor.com") }
+
+    @MainActor func connect() { CursorInstaller.install() }
+    @MainActor func disconnect() { CursorInstaller.uninstall() }
+}
+
+// MARK: - Gemini CLI (experimental)
+
+struct GeminiIntegration: DuckIntegration {
+    let id = "gemini-cli"
+    let displayName = "Gemini CLI"
+    let iconSystemName = "sparkle"
+    let fidelity: IntegrationFidelity = .observeOnly
+    var isToolInstalled: Bool { GeminiExtensionInstaller.isGeminiAvailable() }
+    var isConnected: Bool { GeminiExtensionInstaller.isInstalled() }
+    var capabilityNote: String? {
+        "Experimental. Gemini hooks can't relay decisions, so you approve permissions in the terminal."
+    }
+    var installToolURL: URL? { URL(string: "https://github.com/google-gemini/gemini-cli") }
+
+    @MainActor func connect() { GeminiExtensionInstaller.install() }
+    @MainActor func disconnect() { GeminiExtensionInstaller.uninstall() }
+}
+
+// MARK: - Registry
+
+enum DuckIntegrations {
+    /// All tools the duck knows how to connect to, in display order.
+    static var all: [any DuckIntegration] {
+        [ClaudeCodeIntegration(), CursorIntegration(), GeminiIntegration()]
+    }
+}

--- a/widget/Sources/RubberDuckWidget/DuckProtocol.swift
+++ b/widget/Sources/RubberDuckWidget/DuckProtocol.swift
@@ -145,9 +145,14 @@ struct EvalResult: Codable {
     let textPreview: String?
     let sessionId: String?
     let scores: EvalScores?
+    // Which tool produced this event, for attribution when multiple run at once.
+    // Optional + default nil → absent in old payloads decodes fine; encoder omits
+    // when nil so the broadcast schema (dashboard.html) stays back-compatible.
+    var app: String? = nil   // "claude-code" | "cursor"
+    var repo: String? = nil  // repo folder basename (may be empty)
 
     enum CodingKeys: String, CodingKey {
-        case type, timestamp, source, scores
+        case type, timestamp, source, scores, app, repo
         case textPreview = "text_preview"
         case sessionId = "session_id"
     }

--- a/widget/Sources/RubberDuckWidget/DuckServer.swift
+++ b/widget/Sources/RubberDuckWidget/DuckServer.swift
@@ -35,6 +35,10 @@ class DuckServer: ObservableObject {
     let tmuxBridge: TmuxBridge
     let localTransport: LocalEvalTransport
 
+    /// Derives "Cursor is parked waiting for the user" from /activity pings and
+    /// chirps once. Separate from PermissionGate — it never gates anything.
+    let activityMonitor = CursorActivityMonitor()
+
     /// True when Foundation Models is available on this device.
     let foundationModelsAvailable: Bool
     /// Detailed status for guiding users toward enabling Foundation Models.
@@ -111,7 +115,7 @@ class DuckServer: ObservableObject {
         let sessionContext = SessionContext()
 
         // Shared evaluation logic for /evaluate and /hook/* endpoints
-        let runEval: @Sendable (_ text: String, _ source: String, _ userContext: String, _ sessionId: String) async -> HTTPResponse = { text, source, userContext, sessionId in
+        let runEval: @Sendable (_ text: String, _ source: String, _ userContext: String, _ sessionId: String, _ app: String, _ repo: String) async -> HTTPResponse = { text, source, userContext, sessionId, app, repo in
             guard !text.isEmpty else {
                 return .badRequest("no text")
             }
@@ -191,7 +195,9 @@ class DuckServer: ObservableObject {
                 source: source,
                 textPreview: textPreview,
                 sessionId: sessionId,
-                scores: scores
+                scores: scores,
+                app: app,
+                repo: repo
             )
 
             await broadcaster.broadcast(result)
@@ -239,7 +245,9 @@ class DuckServer: ObservableObject {
                 source: source,
                 textPreview: textPreview,
                 sessionId: "demo",
-                scores: scores
+                scores: scores,
+                app: "claude-code",
+                repo: ""
             )
 
             await broadcaster.broadcast(result)
@@ -263,7 +271,39 @@ class DuckServer: ObservableObject {
             let source = json["source"] as? String ?? "unknown"
             let userContext = json["user_context"] as? String ?? ""
             let sessionId = json["session_id"] as? String ?? ""
-            return await runEval(text, source, userContext, sessionId)
+            // app/repo are optional — absent => Claude Code, the original caller.
+            let app = json["app"] as? String ?? "claude-code"
+            let repo = json["repo"] as? String ?? ""
+            return await runEval(text, source, userContext, sessionId, app, repo)
+        }
+
+        // POST /activity — Cursor non-blocking notifier (pending/resolved).
+        // Pure observation: never returns a permission decision, never blocks.
+        // Drives CursorActivityMonitor, which chirps only if a command stays
+        // unresolved long enough to mean Cursor is parked on its approve prompt.
+        let activityMonitor = self.activityMonitor
+        srv.post("/activity") { request in
+            guard let json = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any] else {
+                return .badRequest("invalid json")
+            }
+            let state = json["state"] as? String ?? ""
+            let kind = json["kind"] as? String ?? "shell"
+            let conversationId = json["conversation_id"] as? String ?? ""
+            let command = json["command"] as? String ?? ""
+            let repo = json["repo"] as? String ?? ""
+            let app = json["app"] as? String ?? "cursor"
+            await MainActor.run {
+                switch state {
+                case "pending":
+                    activityMonitor.handlePending(kind: kind, conversationId: conversationId,
+                                                  command: command, repo: repo, app: app)
+                case "resolved":
+                    activityMonitor.handleResolved(conversationId: conversationId, command: command)
+                default:
+                    break
+                }
+            }
+            return .json(Data("{\"ok\":true}".utf8))
         }
 
         // POST /permission
@@ -576,6 +616,7 @@ class DuckServer: ObservableObject {
         server?.stop()
         server = nil
         isRunning = false
+        activityMonitor.clearAll()  // cancel any armed parked-timers
         DuckLog.log("[server] Stopped")
     }
 }

--- a/widget/Sources/RubberDuckWidget/EvalService.swift
+++ b/widget/Sources/RubberDuckWidget/EvalService.swift
@@ -14,6 +14,9 @@ class EvalService: ObservableObject {
     @Published var reaction: String = ""
     @Published var summary: String = ""
     @Published var source: String = ""
+    /// Which tool produced the latest eval ("claude-code" | "cursor"). Used by
+    /// the coordinator to attribute agent reactions when more than one is active.
+    @Published var app: String = "claude-code"
     @Published var isConnected: Bool = false
 
     // Permission state
@@ -59,6 +62,7 @@ class EvalService: ObservableObject {
             reaction = newScores.reaction ?? ""
             summary = newScores.summary ?? ""
             source = result.source ?? ""
+            app = result.app ?? "claude-code"
             evalCount += 1
             sentiment = newScores.sentiment
 

--- a/widget/Sources/RubberDuckWidget/PreferencesView.swift
+++ b/widget/Sources/RubberDuckWidget/PreferencesView.swift
@@ -11,6 +11,7 @@ struct PreferencesView: View {
 
     enum Tab: String, CaseIterable, Identifiable {
         case intelligence = "Intelligence"
+        case tools = "Coding Tools"
         case behavior = "Behavior"
         case about = "About"
 
@@ -19,6 +20,7 @@ struct PreferencesView: View {
         var icon: String {
             switch self {
             case .intelligence: return "brain.fill"
+            case .tools: return "puzzlepiece.extension.fill"
             case .behavior: return "slider.horizontal.3"
             case .about: return "info.circle"
             }
@@ -64,6 +66,8 @@ struct PreferencesView: View {
                 switch selectedTab {
                 case .intelligence:
                     IntelligencePane()
+                case .tools:
+                    ToolsPane()
                 case .behavior:
                     BehaviorPane()
                 case .about:
@@ -286,6 +290,146 @@ private struct IntelligencePane: View {
 }
 
 // MARK: - Behavior Pane
+
+// MARK: - Coding Tools Pane
+
+/// Cached state for one integration row. Detection (`which claude`, Launch
+/// Services, filesystem scans) is BLOCKING, so it never runs in the view body —
+/// it's computed on a background queue by ToolsModel and published here. Reading
+/// it during a SwiftUI render would spin the main runloop and crash AttributeGraph.
+private struct ToolRow: Identifiable {
+    let id: String
+    let displayName: String
+    let iconSystemName: String
+    let installed: Bool
+    let connected: Bool
+    let fidelityLabel: String
+    let capabilityNote: String?
+    let installToolURL: URL?
+}
+
+@MainActor
+private final class ToolsModel: ObservableObject {
+    @Published private(set) var rows: [ToolRow] = []
+    private let tools = DuckIntegrations.all
+
+    /// Recompute detection OFF the main thread, then publish on main. Mirrors
+    /// MenuStateModel's pattern — keeps all blocking probes out of view rendering.
+    func refresh() {
+        let tools = self.tools
+        DispatchQueue.global(qos: .userInitiated).async {
+            let rows = tools.map { t -> ToolRow in
+                let installed = t.isToolInstalled
+                return ToolRow(
+                    id: t.id, displayName: t.displayName, iconSystemName: t.iconSystemName,
+                    installed: installed, connected: installed && t.isConnected,
+                    fidelityLabel: t.fidelityLabel, capabilityNote: t.capabilityNote,
+                    installToolURL: t.installToolURL
+                )
+            }
+            DispatchQueue.main.async { self.rows = rows }
+        }
+    }
+
+    private func tool(_ id: String) -> (any DuckIntegration)? { tools.first { $0.id == id } }
+
+    func connect(_ id: String) { tool(id)?.connect(); scheduleRefresh() }
+    func disconnect(_ id: String) { tool(id)?.disconnect(); scheduleRefresh() }
+
+    /// connect/disconnect do async work (CLI, file writes) — re-probe a few
+    /// times so the row settles to the real result without reopening the pane.
+    private func scheduleRefresh() {
+        for delay in [0.5, 1.5, 3.0] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in self?.refresh() }
+        }
+    }
+}
+
+/// Lists every tool the duck can watch and lets the user connect/disconnect each
+/// independently. They're not mutually exclusive — the eval server is shared, so
+/// any number can be wired up at once.
+private struct ToolsPane: View {
+    @StateObject private var model = ToolsModel()
+    private var accent: Color { DuckTheme.accent }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Coding Tools")
+                        .font(.title2.bold())
+                    Text("The duck watches every connected tool at once. Check off whichever you use.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                ForEach(Array(model.rows.enumerated()), id: \.element.id) { index, row in
+                    integrationRow(row)
+                    if index < model.rows.count - 1 {
+                        Divider()
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(24)
+        }
+        .onAppear { model.refresh() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            model.refresh()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: PluginInstaller.pluginDidInstallNotification)) { _ in
+            model.refresh()
+        }
+    }
+
+    @ViewBuilder
+    private func integrationRow(_ row: ToolRow) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: row.connected ? "checkmark.circle.fill"
+                              : row.installed ? "circle" : "minus.circle")
+                .foregroundStyle(row.connected ? Color.green : row.installed ? Color.secondary : Color(nsColor: .tertiaryLabelColor))
+                .font(.title3)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: row.iconSystemName)
+                        .foregroundStyle(accent)
+                    Text(row.displayName)
+                        .font(.headline)
+                }
+                Text(row.connected ? "Connected · \(row.fidelityLabel)"
+                     : row.installed ? "Installed, not connected"
+                     : "Not installed on this Mac")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                if let note = row.capabilityNote {
+                    Text(note)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                if !row.installed {
+                    if let url = row.installToolURL {
+                        Button("Get \(row.displayName)") { NSWorkspace.shared.open(url) }
+                    }
+                } else if row.connected {
+                    Button("Disconnect") { model.disconnect(row.id) }
+                } else {
+                    Button("Connect") { model.connect(row.id) }
+                        .buttonStyle(.borderedProminent)
+                        .tint(accent)
+                }
+            }
+        }
+    }
+}
 
 private struct BehaviorPane: View {
     @EnvironmentObject var speechService: SpeechService

--- a/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
+++ b/widget/Sources/RubberDuckWidget/RubberDuckWidgetApp.swift
@@ -393,6 +393,17 @@ struct RubberDuckWidgetApp: App {
             )
         }
 
+        // Cursor installer voice feedback (same lane/policy as the plugin).
+        CursorInstaller.onSpeak = { [weak speech] text in
+            speech?.scheduleSpeech(
+                text,
+                kind: .system,
+                lane: .manual,
+                policy: .latestWins,
+                interruptibility: .freelyInterruptible
+            )
+        }
+
         // Store service refs so AppDelegate can turn off the companion
         AppDelegate.speechService = speech
         AppDelegate.coordinator = coordinator
@@ -466,6 +477,18 @@ struct RubberDuckWidgetApp: App {
             )
         }
         transport.onClearThinking = { [weak coordinator] in coordinator?.clearThinking() }
+
+        // Cursor "parked waiting on you" chirp — single short ambient line that
+        // drops if the duck is busy. Never gates anything (Cursor owns approval).
+        server.activityMonitor.onChirp = { [weak speech] text in
+            speech?.scheduleSpeech(
+                text,
+                kind: .system,
+                lane: .ambient,
+                policy: .dropIfBusy,
+                interruptibility: .freelyInterruptible
+            )
+        }
         transport.onPermissionResolved = { [weak coordinator] hadPassthrough in coordinator?.handlePermissionResolved(hadPassthrough: hadPassthrough) }
         transport.onMelodyStart = { [weak coordinator] in coordinator?.startMelody() }
         transport.onMelodyStop = { [weak coordinator] in coordinator?.stopMelody() }
@@ -505,6 +528,12 @@ struct RubberDuckWidgetApp: App {
                 // Setup checklist — non-blocking SwiftUI window, after greeting starts
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     AppDelegate.checkSetup()
+                }
+                // If Cursor is installed but not yet wired up, the duck offers
+                // to connect itself — out loud, once per version. Deferred well
+                // past the greeting so it doesn't talk over it.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
+                    CursorInstaller.offerIfAppropriate()
                 }
             }
 
@@ -869,6 +898,7 @@ class DraggableView: NSView {
 @MainActor
 final class MenuStateModel: ObservableObject {
     @Published private(set) var isClaudeInstalled: Bool = false
+    @Published private(set) var isCursorReady: Bool = false
     @Published private(set) var launchAtLogin: Bool = false
     @Published var experimentalEnabled: Bool {
         didSet { UserDefaults.standard.set(experimentalEnabled, forKey: "experimentalEnabled") }
@@ -891,6 +921,7 @@ final class MenuStateModel: ObservableObject {
 
     func refresh() {
         isClaudeInstalled = PluginInstaller.findClaude() != nil
+        isCursorReady = CursorInstaller.isCursorInstalled() && CursorInstaller.areHooksInstalled()
         launchAtLogin = SMAppService.mainApp.status == .enabled
     }
 
@@ -939,6 +970,12 @@ struct SetupCommands: Commands {
             Button("Export Plugin Zip...") {
                 PluginInstaller.exportPluginZip()
             }
+
+            Button(model.isCursorReady ? "Cursor Hooks Installed ✓" : "Connect to Cursor") {
+                CursorInstaller.install()
+                model.refresh()
+            }
+            .disabled(model.isCursorReady)
 
             Divider()
 

--- a/widget/Sources/RubberDuckWidget/StatusBarManager.swift
+++ b/widget/Sources/RubberDuckWidget/StatusBarManager.swift
@@ -297,6 +297,22 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
         claudeSession.image = NSImage(systemSymbolName: "terminal.fill", accessibilityDescription: "Terminal")
         menu.addItem(claudeSession)
 
+        // --- Cursor integration (only shown if Cursor is installed) ---
+        if CursorInstaller.isCursorInstalled() {
+            if CursorInstaller.areHooksInstalled() {
+                let item = NSMenuItem(title: "Cursor Hooks Installed ✓", action: nil, keyEquivalent: "")
+                item.image = NSImage(systemSymbolName: "cursorarrow.rays", accessibilityDescription: "Cursor")
+                item.isEnabled = false
+                menu.addItem(item)
+            } else {
+                let item = NSMenuItem(title: "Connect to Cursor", action: #selector(connectCursor), keyEquivalent: "")
+                item.target = self
+                item.image = NSImage(systemSymbolName: "cursorarrow.rays", accessibilityDescription: "Cursor")
+                item.subtitle = "Wire the duck into Cursor's agent"
+                menu.addItem(item)
+            }
+        }
+
         // --- Permission warnings (only if something is wrong) ---
         let micOK = speechService.micPermissionGranted
         let speechOK = speechService.speechPermissionGranted
@@ -476,6 +492,10 @@ final class StatusBarManager: NSObject, NSMenuDelegate {
 
     @objc private func startClaudeSession() {
         CLISession.launch()
+    }
+
+    @objc private func connectCursor() {
+        CursorInstaller.install()
     }
 
     @objc private func openUpdatePage() {
@@ -793,6 +813,59 @@ enum PluginInstaller {
                 onSpeak?("Claude Code isn't installed yet. I'll show you how.")
                 showSetupChecklist(hasClaude: hasDesktop, hasPlugin: DuckConfig.lastInstalledPluginVersion != nil)
             }
+        }
+    }
+
+    /// Is the duck plugin actually installed for Claude? Mirrors the check in
+    /// AppDelegate.checkSetup / SetupChecklistView — the plugin cache dir exists
+    /// and holds at least one version. Centralized here so the integrations
+    /// list and the setup UI agree.
+    static func isPluginInstalled() -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let pluginDir = "\(home)/.claude/plugins/cache/duck-duck-duck-marketplace/duck-duck-duck"
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: pluginDir, isDirectory: &isDir), isDir.boolValue else {
+            return false
+        }
+        return (try? FileManager.default.contentsOfDirectory(atPath: pluginDir))?.isEmpty == false
+    }
+
+    /// Is Claude (CLI or Desktop) present on this Mac?
+    static func isClaudeAvailable() -> Bool {
+        findClaude() != nil || isClaudeDesktopInstalled()
+    }
+
+    /// Remove the plugin. CLI uninstall when available (properly de-registers);
+    /// otherwise best-effort disable in settings.json so Claude stops loading it.
+    static func uninstall() {
+        if let claude = findClaude() {
+            Task { @MainActor in onSpeak?("Disconnecting from Claude Code.") }
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = run(claude, args: ["plugin", "uninstall", "duck-duck-duck"])
+                Task { @MainActor in
+                    onSpeak?("Disconnected from Claude Code.")
+                    NotificationCenter.default.post(name: pluginDidInstallNotification, object: nil)
+                }
+            }
+            return
+        }
+        // No CLI — flip enabledPlugins[...] = false in settings.json.
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let settingsFile = "\(home)/.claude/settings.json"
+        let fm = FileManager.default
+        if let data = fm.contents(atPath: settingsFile),
+           var settings = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            let key = "duck-duck-duck@duck-duck-duck-marketplace"
+            var enabled = settings["enabledPlugins"] as? [String: Any] ?? [:]
+            enabled[key] = false
+            settings["enabledPlugins"] = enabled
+            if let out = try? JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted, .sortedKeys]) {
+                try? out.write(to: URL(fileURLWithPath: settingsFile), options: .atomic)
+            }
+        }
+        Task { @MainActor in
+            onSpeak?("Disabled the plugin. Restart Claude to apply.")
+            NotificationCenter.default.post(name: pluginDidInstallNotification, object: nil)
         }
     }
 
@@ -1276,6 +1349,42 @@ enum GeminiExtensionInstaller {
             automaticInstall(gemini: gemini)
         } else {
             Task { @MainActor in clipboardInstall() }
+        }
+    }
+
+    /// Is the Gemini CLI present?
+    static func isGeminiAvailable() -> Bool {
+        findTool("gemini") != nil
+    }
+
+    /// Best-effort detection of our installed Gemini extension. The CLI drops
+    /// extensions under ~/.gemini/extensions/<name>; we match any folder whose
+    /// name mentions the duck. Experimental tool — detection is heuristic.
+    static func isInstalled() -> Bool {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let extDir = "\(home)/.gemini/extensions"
+        guard let entries = try? FileManager.default.contentsOfDirectory(atPath: extDir) else {
+            return false
+        }
+        let needles = ["rubber-duck", "rubber_duck", "duck-duck-duck", "duckduckduck"]
+        return entries.contains { name in
+            let lower = name.lowercased()
+            return needles.contains { lower.contains($0) }
+        }
+    }
+
+    /// Remove the Gemini extension (best-effort; CLI required).
+    static func uninstall() {
+        guard let gemini = findTool("gemini") else { return }
+        DispatchQueue.global(qos: .userInitiated).async {
+            let proc = Process()
+            proc.executableURL = URL(fileURLWithPath: gemini)
+            // The CLI accepts the source repo for uninstall as well as install.
+            proc.arguments = ["extensions", "uninstall", "ideo/Rubber-Duck"]
+            proc.standardOutput = FileHandle.nullDevice
+            proc.standardError = FileHandle.nullDevice
+            try? proc.run()
+            proc.waitUntilExit()
         }
     }
 


### PR DESCRIPTION
Brings the duck to **Cursor (1.7+)** alongside Claude Code, and adds a unified **Coding Tools** pane for connecting multiple tools at once. The eval server is shared, so the duck can watch a Claude Code session and a Cursor agent simultaneously.

## Cursor integration (`cursor/`)
- **Scoring:** adapter hooks translate Cursor's hook JSON to the existing `/evaluate` endpoint — `beforeSubmitPrompt` → user scoring, `afterAgentResponse` → response scoring (Cursor's `stop` carries no text, so we use the after-response event).
- **Permissions = non-blocking notifier, not a gate.** Cursor owns its own approval UI and ignores hook `allow`/`ask` (only `deny` is honored), so `on-permission.sh` fires a fire-and-forget `/activity` "pending" ping and returns instantly with **no decision** — Cursor's approve/deny is never influenced or blocked. `CursorActivityMonitor` pairs it with the `afterShellExecution` "resolved" ping and **chirps once** only if a command stays unresolved (Cursor parked on its approve prompt). Auto-run commands stay silent. MCP never chirps (no confirmed resolve event).
- **One-click install:** widget writes `~/.cursor/hooks.json` + copies scripts to a space-free path (`~/.duck-duck-duck/cursor-hooks`; Cursor runs commands through a shell, so a space in the path breaks them with exit 127). Detects Cursor on launch and offers to connect out loud.

## Coding Tools preferences pane
- `DuckIntegration` protocol unifies Claude Code / Cursor / Gemini behind detect + connect/disconnect, with honest per-tool fidelity (Claude Code: voice permissions; Cursor: waiting-for-you alerts; Gemini: scores only).
- Detection runs off the main thread (it shells out) to avoid an AttributeGraph crash from blocking the SwiftUI render loop.

## Multi-tool attribution
- Hooks tag events with `app` + `repo` (folder basename, computed in-hook to dodge JSON slash-escaping). Server defaults `app=claude-code`, so existing payloads are unaffected. The duck names the program only for **agent output**, only on a real switch after a gap; user prompts are never attributed. Waiting chirps say program + repo.

## Hardening
Design was hardened via a parallel adversarial review **before** implementation — resolved-before-pending race (MiniServer spawns unordered Tasks), denied-command leak, MainActor timer (a bare `Timer` on the server queue never fires), MCP asymmetry, back-compat — all folded in and unit-simulated. The existing `/permission` voice gate and `PermissionGate` are **untouched**; Claude Code's flow is unchanged.

## Status / how to explore
- ✅ **Verified:** Cursor wiring fires correctly; scoring works in chat and agent; non-blocking + non-influence guarantee (permission prompts are never blocked or decided by the duck); the install/refresh flow; back-compat.
- ⏳ **Not yet verified:** the live "waiting" chirp on a *genuinely parked* approval. Auto-run/allowlisted commands correctly stay silent — to see the chirp, turn off Cursor's auto-run/allowlist (or run a command it will actually stop and ask about) and wait ~2.5s. Threshold lives in `CursorActivityMonitor.parkedThreshold`.

To try: `make run` → **Coding Tools → Connect**, restart Cursor. After pulling new changes, Disconnect → Connect to refresh the installed scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)